### PR TITLE
Move row scaling to experimental

### DIFF
--- a/src/iterative_ensemble_smoother/__init__.py
+++ b/src/iterative_ensemble_smoother/__init__.py
@@ -4,13 +4,11 @@ problems." for details about the algorithm.
 
 """
 from ._ensemble_smoother import ensemble_smoother_update_step
-from ._ensemble_smoother_row_scaling import ensemble_smoother_update_step_row_scaling
 from ._ies import InversionType
 from ._iterative_ensemble_smoother import IterativeEnsembleSmoother
 
 __all__ = [
     "ensemble_smoother_update_step",
     "IterativeEnsembleSmoother",
-    "ensemble_smoother_update_step_row_scaling",
     "InversionType",
 ]

--- a/src/iterative_ensemble_smoother/experimental.py
+++ b/src/iterative_ensemble_smoother/experimental.py
@@ -1,3 +1,7 @@
+"""
+Contains (publicly available, but not officially supported) experimental
+features of iterative_ensemble_smoother
+"""
 import numpy as np
 
 from ._ies import InversionType, make_D, make_E, make_X

--- a/tests/test_ensemble_smoother.py
+++ b/tests/test_ensemble_smoother.py
@@ -7,6 +7,9 @@ from numpy import testing
 from scipy.special import erf
 
 import iterative_ensemble_smoother as ies
+from iterative_ensemble_smoother.experimental import (
+    ensemble_smoother_update_step_row_scaling,
+)
 
 
 # We fix the random seed in the tests for convenience
@@ -127,7 +130,7 @@ class RowScaling:
 
 
 def test_ensemble_smoother_update_step_with_rowscaling(snapshot, initial_A, initial_S):
-    ((new_A, _),) = ies.ensemble_smoother_update_step_row_scaling(
+    ((new_A, _),) = ensemble_smoother_update_step_row_scaling(
         initial_S,
         [(initial_A, RowScaling())],
         observation_errors,


### PR DESCRIPTION
This PR moves the experimental row_scaling feature to `iterative_ensemble_smoother.experimental` so that it is completely separate from normal usage.

This change is blocking https://github.com/equinor/ert/pull/3844 .