### PR TITLE
Specify in which folder tests are saved

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,8 @@ dev = [
 ]
 
 [tool.setuptools_scm]
+
+[tool.pytest.ini_options]
+testpaths = [
+    "tests"
+]


### PR DESCRIPTION
This to avoid python files in, say the docs-folder being run during test-discovery.