### PR TITLE
Measure memory usage of ES

### DIFF
--- a/src/iterative_ensemble_smoother/_ensemble_smoother.py
+++ b/src/iterative_ensemble_smoother/_ensemble_smoother.py
@@ -1,8 +1,10 @@
 from typing import TYPE_CHECKING, Optional
 
 import numpy as np
+import numpy.typing as npt
 
 from ._ies import InversionType, make_D, make_E, make_X
+from iterative_ensemble_smoother.utils import _compute_AA_projection
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -45,15 +47,17 @@ def ensemble_smoother_update_step(
     E = (E.T / observation_errors).T
     S = (S.T / observation_errors).T
 
+    if projection and (A.shape[0] <= A.shape[1] - 1):
+        AA_projection = _compute_AA_projection(A)
+        S = S @ AA_projection
+
     X = make_X(
-        A,
         S,
         R,
         E,
         D,
         inversion,
         truncation,
-        projection,
         np.zeros((S.shape[1], S.shape[1])),
         1.0,
         1,

--- a/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
+++ b/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from ._ies import InversionType, ModuleData, init_update, make_D, make_E, update_A
+from iterative_ensemble_smoother.utils import _compute_AA_projection
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -109,6 +110,10 @@ class IterativeEnsembleSmoother:
 
         init_update(self._module_data, ensemble_mask, observation_mask)
 
+        if projection and (A.shape[0] <= A.shape[1] - 1):
+            AA_projection = _compute_AA_projection(A)
+            S = S @ AA_projection
+
         update_A(
             self._module_data,
             A,
@@ -118,7 +123,6 @@ class IterativeEnsembleSmoother:
             D,
             inversion,
             truncation,
-            projection,
             step_length,
         )
         self._module_data.iteration_nr += 1

--- a/src/iterative_ensemble_smoother/experimental.py
+++ b/src/iterative_ensemble_smoother/experimental.py
@@ -5,6 +5,7 @@ features of iterative_ensemble_smoother
 import numpy as np
 
 from ._ies import InversionType, make_D, make_E, make_X
+from iterative_ensemble_smoother.utils import _compute_AA_projection
 
 
 def ensemble_smoother_update_step_row_scaling(
@@ -29,14 +30,12 @@ def ensemble_smoother_update_step_row_scaling(
     S = (S.T / observation_errors).T
     for (A, row_scale) in A_with_row_scaling:
         X = make_X(
-            A,
             S,
             R,
             E,
             D,
             inversion,
             truncation,
-            False,
             np.zeros((S.shape[1], S.shape[1])),
             1.0,
             1,

--- a/src/iterative_ensemble_smoother/utils.py
+++ b/src/iterative_ensemble_smoother/utils.py
@@ -1,0 +1,10 @@
+import numpy as np
+import numpy.typing as npt
+
+
+def _compute_AA_projection(A: npt.NDArray[np.double]) -> npt.NDArray[np.double]:
+    """A^+A projection is necessary when the parameter matrix has less rows than
+    columns, and when the forward model is non-linear. Section 2.4.3
+    """
+    _, _, vh = np.linalg.svd(A - A.mean(axis=1, keepdims=True), full_matrices=False)
+    return vh.T @ vh

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+rng = np.random.default_rng()
+
+from iterative_ensemble_smoother.utils import _compute_AA_projection
+
+
+def test_that_svd_projection_is_same_as_pinv():
+    N = 10
+    p = 5
+    X = rng.standard_normal(size=(p, N))
+    A = X - X.mean(axis=1, keepdims=True)
+    projection_pinv = np.linalg.pinv(A) @ A
+    projection_svd = _compute_AA_projection(A)
+    assert np.isclose(projection_pinv, projection_svd).all()


### PR DESCRIPTION
Goal is to reduce memory footprint and try to come up with some tests to make sure it stays that way.

## Notes

Test passes is I wrap `A` in `np.asfortranarray`.
There can be several reasons for this, one being that my test is bad, that is that the assert does not make sense.
Also, it should not be necessary to cast to fortran style array if I understand pybind's documentation correctly.