### PR TITLE
Center response ensemble before passing to C++

### DIFF
--- a/src/iterative_ensemble_smoother/_ensemble_smoother.py
+++ b/src/iterative_ensemble_smoother/_ensemble_smoother.py
@@ -53,7 +53,8 @@ def ensemble_smoother_update_step(
         response_ensemble = response_ensemble @ AA_projection
 
     X = make_X(
-        response_ensemble,
+        (response_ensemble - response_ensemble.mean(axis=1, keepdims=True))
+        / np.sqrt(realizations - 1),
         R,
         E,
         D,

--- a/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
+++ b/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
@@ -117,7 +117,8 @@ class IterativeEnsembleSmoother:
         update_A(
             self._module_data,
             parameter_ensemble,
-            response_ensemble,
+            (response_ensemble - response_ensemble.mean(axis=1, keepdims=True))
+            / np.sqrt(realizations - 1),
             R,
             E,
             D,

--- a/src/iterative_ensemble_smoother/experimental.py
+++ b/src/iterative_ensemble_smoother/experimental.py
@@ -30,7 +30,8 @@ def ensemble_smoother_update_step_row_scaling(
     response_ensemble = (response_ensemble.T / observation_errors).T
     for (A, row_scale) in A_with_row_scaling:
         X = make_X(
-            response_ensemble,
+            (response_ensemble - response_ensemble.mean(axis=1, keepdims=True))
+            / np.sqrt(realizations - 1),
             R,
             E,
             D,


### PR DESCRIPTION
Removes the need to create centered and normalized matrix in C++,
and is more according to the notation used in the paper,
where Y referes to centered and normalized responses.