### PR TITLE
Reduce state held by `ies`

### DIFF
--- a/src/iterative_ensemble_smoother/_ensemble_smoother.py
+++ b/src/iterative_ensemble_smoother/_ensemble_smoother.py
@@ -4,7 +4,7 @@ import numpy as np
 
 rng = np.random.default_rng()
 
-from ._ies import InversionType, make_D, make_E, make_X
+from ._ies import InversionType, make_D, make_E, create_transition_matrix
 from iterative_ensemble_smoother.utils import _compute_AA_projection, _validate_inputs
 
 if TYPE_CHECKING:
@@ -62,7 +62,7 @@ def ensemble_smoother_update_step(
         AA_projection = _compute_AA_projection(parameter_ensemble)
         response_ensemble = response_ensemble @ AA_projection
 
-    X = make_X(
+    X = create_transition_matrix(
         (response_ensemble - response_ensemble.mean(axis=1, keepdims=True))
         / np.sqrt(ensemble_size - 1),
         R,

--- a/src/iterative_ensemble_smoother/_ensemble_smoother.py
+++ b/src/iterative_ensemble_smoother/_ensemble_smoother.py
@@ -72,6 +72,5 @@ def ensemble_smoother_update_step(
         truncation,
         np.zeros((ensemble_size, ensemble_size)),
         1.0,
-        1,
     )
     return parameter_ensemble @ X

--- a/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
+++ b/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
@@ -29,7 +29,7 @@ class IterativeEnsembleSmoother:
         dec_steplength: float = 2.5,
     ):
         self.iteration_nr = 1
-        self._ensemble_size = ensemble_size
+        self._initial_ensemble_size = ensemble_size
         self.max_steplength = max_steplength
         self.min_steplength = min_steplength
         self.dec_steplength = dec_steplength
@@ -106,7 +106,7 @@ class IterativeEnsembleSmoother:
 
         num_params = parameter_ensemble.shape[0]
         num_obs = len(observation_values)
-        # Note that this may differ from self._ensemble_size,
+        # Note that this may differ from self._initial_ensemble_size,
         # as realizations may get deactivated between iterations.
         ensemble_size = parameter_ensemble.shape[1]
         if step_length is None:
@@ -122,7 +122,7 @@ class IterativeEnsembleSmoother:
         E = (E.T / observation_errors).T
         response_ensemble = (response_ensemble.T / observation_errors).T
 
-        if projection and (num_params < self._ensemble_size - 1):
+        if projection and (num_params < self._initial_ensemble_size - 1):
             AA_projection = _compute_AA_projection(parameter_ensemble)
             response_ensemble = response_ensemble @ AA_projection
 
@@ -132,7 +132,7 @@ class IterativeEnsembleSmoother:
         coefficient_matrix = update_A(
             parameter_ensemble,
             (response_ensemble - response_ensemble.mean(axis=1, keepdims=True))
-            / np.sqrt(self._ensemble_size - 1),
+            / np.sqrt(self._initial_ensemble_size - 1),
             R,
             E,
             D,

--- a/src/iterative_ensemble_smoother/experimental.py
+++ b/src/iterative_ensemble_smoother/experimental.py
@@ -6,7 +6,7 @@ import numpy as np
 
 rng = np.random.default_rng()
 
-from ._ies import InversionType, make_D, make_E, make_X
+from ._ies import InversionType, make_D, make_E, create_transition_matrix
 
 
 def ensemble_smoother_update_step_row_scaling(
@@ -31,7 +31,7 @@ def ensemble_smoother_update_step_row_scaling(
     E = (E.T / observation_errors).T
     response_ensemble = (response_ensemble.T / observation_errors).T
     for (A, row_scale) in A_with_row_scaling:
-        X = make_X(
+        X = create_transition_matrix(
             (response_ensemble - response_ensemble.mean(axis=1, keepdims=True))
             / np.sqrt(ensemble_size - 1),
             R,

--- a/src/iterative_ensemble_smoother/experimental.py
+++ b/src/iterative_ensemble_smoother/experimental.py
@@ -41,7 +41,6 @@ def ensemble_smoother_update_step_row_scaling(
             truncation,
             np.zeros((ensemble_size, ensemble_size)),
             1.0,
-            1,
         )
         row_scale.multiply(A, X)
     return A_with_row_scaling

--- a/src/iterative_ensemble_smoother/ies.cpp
+++ b/src/iterative_ensemble_smoother/ies.cpp
@@ -269,7 +269,7 @@ MatrixXd makeX(py::EigenDRef<MatrixXd> Y, py::EigenDRef<MatrixXd> R,
                py::EigenDRef<MatrixXd> E, py::EigenDRef<MatrixXd> D,
                const Inversion ies_inversion,
                const std::variant<double, int> &truncation, MatrixXd &W0,
-               double ies_steplength, int iteration_nr)
+               double ies_steplength)
 
 {
   const int ens_size = Y.cols();
@@ -356,12 +356,10 @@ MatrixXd updateA(Data &data,
                  const std::variant<double, int> &truncation,
                  double ies_steplength) {
 
-  int iteration_nr = data.iteration_nr;
-
   auto const ensemble_size = A.cols();
 
   auto X = makeX(Y, Rin, Ein, D, ies_inversion, truncation, coefficient_matrix,
-                 ies_steplength, iteration_nr);
+                 ies_steplength);
 
   A *= X;
 
@@ -402,7 +400,7 @@ PYBIND11_MODULE(_ies, m) {
       .def(py::init<int>())
       .def_readwrite("iteration_nr", &Data::iteration_nr);
   m.def("make_X", &makeX, "Y0"_a, "R"_a, "E"_a, "D"_a, "ies_inversion"_a,
-        "truncation"_a, "W0"_a, "ies_steplength"_a, "iteration_nr"_a);
+        "truncation"_a, "W0"_a, "ies_steplength"_a);
   m.def("make_E", &makeE, "obs_errors"_a, "noise"_a);
   m.def("make_D", &makeD, "obs_values"_a, "E"_a, "S"_a);
   m.def("update_A", &updateA, "data"_a, "A"_a, "Y"_a, "R"_a, "E"_a, "D"_a,

--- a/tests/test_theoretical_property.py
+++ b/tests/test_theoretical_property.py
@@ -18,7 +18,7 @@ def test_that_update_is_according_to_theory():
     Here we use this property, and assume that the forward model is the identity
     to test analysis steps.
     """
-    N = 1000
+    N = 1500
     nparam = 3
     var = 2
 
@@ -41,8 +41,15 @@ def test_that_update_is_according_to_theory():
         inversion=ies.InversionType.EXACT,
     )
 
+    ens_mask = np.array([True] * N)
+    ens_mask[:5] = False
     A_IES = ies.IterativeEnsembleSmoother(ensemble_size=N).update_step(
-        Y, A, observation_errors, observation_values, step_length=1.0
+        Y[:, ens_mask],
+        A[:, ens_mask],
+        observation_errors,
+        observation_values,
+        step_length=1.0,
+        ensemble_mask=ens_mask,
     )
 
     for i in range(nparam):


### PR DESCRIPTION
Resolves: #52 
Resolves: #53 
Resolves: #45 
Resolves: #63 

ERT passes matrices to `ies` that have already been sliced, i.e., deactivated observations and realizations have been removed.
One reason for `ies` to hold state was to be able to deal with observations and realizations being deactivated in-between iterations.
Assuming that users of `ies` manage this themselves allows us to hold less state and simplify the code.