### PR TITLE
Remove unnecessary loop from exact inversion

### DIFF
--- a/src/iterative_ensemble_smoother/ies.cpp
+++ b/src/iterative_ensemble_smoother/ies.cpp
@@ -7,7 +7,6 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-using Eigen::ComputeFullU;
 using Eigen::ComputeThinU;
 using Eigen::ComputeThinV;
 using Eigen::MatrixXd;
@@ -208,36 +207,26 @@ void subspace_inversion(MatrixXd &W, const Inversion ies_inversion,
   Eigen::Map<VectorXd> eig_vector(eig.data(), eig.size());
   MatrixXd X3 = genX3(X1, H, eig_vector);
 
-  // Update data->W = (1-ies_steplength) * data->W +  ies_steplength * S' * X3
   // (Line 9)
   W = ies_steplength * S.transpose() * X3 + (1.0 - ies_steplength) * W;
 }
 
 /**
- * Section 3.2 - Exact inversion
- * This calculates (S^T*S + I_N)^{-1} by taking the SVD of (S^T*S + I_N),
- * and since (S^T*S + I_N) is symmetric positive semi-definite we have that U=V
- * and hence (S^T*S + I_N)^{-1} = U * \Sigma^{-1} * U^T.
- */
+ * Section 3.2 - Exact inversion assuming diagonal error covariance matrix
+  */
 void exact_inversion(MatrixXd &W, const MatrixXd &S, const MatrixXd &H,
                      double ies_steplength) {
   int ens_size = S.cols();
 
-  MatrixXd StS = S.transpose() * S + MatrixXd::Identity(ens_size, ens_size);
+  MatrixXd C = S.transpose() * S + MatrixXd::Identity(ens_size, ens_size);
 
-  auto svd = StS.bdcSvd(ComputeFullU);
-  MatrixXd Z = svd.matrixU();
-  VectorXd eig = svd.singularValues();
+  auto svd = C.bdcSvd(Eigen::ComputeFullV);
 
-  MatrixXd ZtStH = Z.transpose() * S.transpose() * H;
-
-  for (int i = 0; i < ens_size; i++)
-    ZtStH.row(i) /= eig[i];
-
-  // Update data->W = (1-ies_steplength) * data->W +  ies_steplength * Z *
-  // (Lamda^{-1}) Z' S' H (Line 9)
-  W = ies_steplength * Z * ZtStH + (1.0 - ies_steplength) * W;
-}
+  W = W - ies_steplength *
+              (W - svd.matrixV() *
+                       svd.singularValues().cwiseInverse().asDiagonal() *
+                       svd.matrixV().transpose() * S.transpose() * H);
+  }
 
 /**
  * @param Y Predicted ensemble anomalies normalized by sqrt(N-1),


### PR DESCRIPTION
Creates fewer matrices and uses the exact same expression for W as given in paper.