### PR TITLE
Remove unnecessary build_ext

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,4 +20,4 @@ ext_modules = [
     ),
 ]
 
-setup(cmdclass={"build_ext": build_ext}, ext_modules=ext_modules)
+setup(ext_modules=ext_modules)


### PR DESCRIPTION
Resolves: #37

Not needed when cxx_std=17 is set