### PR TITLE
Reproducibility, linalg speedup, renaming

### DIFF
--- a/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
+++ b/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
@@ -10,7 +10,6 @@ from ._ies import InversionType, create_coefficient_matrix
 from iterative_ensemble_smoother.utils import (
     _validate_inputs,
     _create_errors,
-    check_random_state,
 )
 
 
@@ -45,7 +44,7 @@ class SIES:
         max_steplength: float = 0.6,
         min_steplength: float = 0.3,
         dec_steplength: float = 2.5,
-        random_state: Optional[None, int, np.random.RandomState] = None,
+        seed: Optional[int] = None,
     ):
         self._initial_ensemble_size = ensemble_size
         self.iteration_nr = 1
@@ -53,7 +52,7 @@ class SIES:
         self.min_steplength = min_steplength
         self.dec_steplength = dec_steplength
         self.coefficient_matrix = np.zeros(shape=(ensemble_size, ensemble_size))
-        self._rng = check_random_state(random_state)
+        self.rng = np.random.default_rng(seed)
 
     def _get_steplength(self, iteration_nr: int) -> float:
         """
@@ -122,7 +121,7 @@ class SIES:
             step_length = self._get_steplength(self.iteration_nr)
 
         if noise is None:
-            noise = self._rng.standard_normal(size=(num_obs, ensemble_size))
+            noise = self.rng.standard_normal(size=(num_obs, ensemble_size))
 
         # Columns of E should be sampled from N(0,Cdd) and centered, Evensen 2019
         if observation_errors.ndim == 2:

--- a/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
+++ b/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
@@ -6,12 +6,11 @@ import numpy as np
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-rng = np.random.default_rng()
-
 from ._ies import InversionType, create_coefficient_matrix
 from iterative_ensemble_smoother.utils import (
     _validate_inputs,
     _create_errors,
+    check_random_state,
 )
 
 
@@ -46,6 +45,7 @@ class SIES:
         max_steplength: float = 0.6,
         min_steplength: float = 0.3,
         dec_steplength: float = 2.5,
+        random_state: Optional[None, int, np.random.RandomState] = None,
     ):
         self._initial_ensemble_size = ensemble_size
         self.iteration_nr = 1
@@ -53,6 +53,7 @@ class SIES:
         self.min_steplength = min_steplength
         self.dec_steplength = dec_steplength
         self.coefficient_matrix = np.zeros(shape=(ensemble_size, ensemble_size))
+        self._rng = check_random_state(random_state)
 
     def _get_steplength(self, iteration_nr: int) -> float:
         """
@@ -121,10 +122,10 @@ class SIES:
             step_length = self._get_steplength(self.iteration_nr)
 
         if noise is None:
-            noise = rng.standard_normal(size=(num_obs, ensemble_size))
+            noise = self._rng.standard_normal(size=(num_obs, ensemble_size))
 
         # Columns of E should be sampled from N(0,Cdd) and centered, Evensen 2019
-        if len(observation_errors.shape) == 2:
+        if observation_errors.ndim == 2:
             E = np.linalg.cholesky(observation_errors) @ noise
         else:
             # This is equivalent to cholesky(np.diag(observation_errors**2)) @ noise as the Cholesky
@@ -133,23 +134,23 @@ class SIES:
             E = noise * observation_errors.reshape(num_obs, 1)
         E -= E.mean(axis=1, keepdims=True)
 
-        R, observation_errors = _create_errors(observation_errors, inversion)
+        R, observation_errors_std = _create_errors(observation_errors, inversion)
 
         D = (E + observation_values.reshape(num_obs, 1)) - response_ensemble
 
         # Scale D and E with observation error standard deviations.
-        D /= observation_errors.reshape(num_obs, 1)
-        E /= observation_errors.reshape(num_obs, 1)
+        D /= observation_errors_std.reshape(num_obs, 1)
+        E /= observation_errors_std.reshape(num_obs, 1)
 
         if param_ensemble is not None:
             projected_response = response_ensemble @ _response_projection(
                 param_ensemble
             )
-            _response_ensemble = projected_response / observation_errors.reshape(
+            _response_ensemble = projected_response / observation_errors_std.reshape(
                 num_obs, 1
             )
         else:
-            _response_ensemble = response_ensemble / observation_errors.reshape(
+            _response_ensemble = response_ensemble / observation_errors_std.reshape(
                 num_obs, 1
             )
         _response_ensemble -= _response_ensemble.mean(axis=1, keepdims=True)

--- a/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
+++ b/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
@@ -35,6 +35,7 @@ class SIES:
     :param max_steplength: parameter used to tweaking the step length.
     :param min_steplength: parameter used to tweaking the step length.
     :param dec_steplength: parameter used to tweaking the step length.
+    :param seed: Integer used to seed the random number generator.
     """
 
     def __init__(

--- a/src/iterative_ensemble_smoother/utils.py
+++ b/src/iterative_ensemble_smoother/utils.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 from typing import Tuple, Optional, TYPE_CHECKING
 
 import numpy as np
-import numbers
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -92,34 +91,3 @@ def _create_errors(
         R = None
 
     return R, observation_errors
-
-
-def check_random_state(
-    seed: Optional[None, int, np.random.RandomState]
-) -> np.random.RandomState:
-    """Turn seed into a np.random.RandomState instance.
-
-    Parameters
-    ----------
-    seed : None, int or instance of RandomState
-        If seed is None, return the RandomState singleton used by np.random.
-        If seed is an int, return a new RandomState instance seeded with seed.
-        If seed is already a RandomState instance, return it.
-        Otherwise raise ValueError.
-
-    Returns
-    -------
-    :class:`numpy:numpy.random.RandomState`
-        The random state object based on `seed` parameter.
-    """
-    # This code is from sklearn:
-    # https://scikit-learn.org/stable/modules/generated/sklearn.utils.check_random_state.html
-    if seed is None or seed is np.random:
-        return np.random.mtrand._rand
-    if isinstance(seed, numbers.Integral):
-        return np.random.RandomState(seed)
-    if isinstance(seed, np.random.RandomState):
-        return seed
-    raise ValueError(
-        "%r cannot be used to seed a numpy.random.RandomState instance" % seed
-    )


### PR DESCRIPTION
- Using `random_state` as input along with a `check_random_state()` function to facilitate reproducibility. This is how sklearn and other packages typically do it.
- Replaced the `len(array.shape)` checks with `array.ndim`. Hopefully a bit more readable
- Renamed a variable
- Avoid forming two diagonal matrices to pre-and-post multiply, instead just multiply each row/column. Goes from `O(m^3)` to `O(m^2)`. Probably not a big practical speedup, since this is unlikely to be a bottleneck, but might as well optimize these kinds of operations in my opinion.

This is a first step toward getting rid of `noise`, which I will do in another PR

I chose to just pass an integer `seed` instead of allowing a random state object, after reading
- https://github.com/scikit-learn/scikit-learn/issues/14042
- https://github.com/scikit-learn/scikit-learn/issues/16988
- https://numpy.org/doc/stable/reference/random/generator.html#numpy.random.default_rng

I don't see a usecase where an integer seed is not good enough.