### PR TITLE
Refactor IES

### DIFF
--- a/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
+++ b/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 from iterative_ensemble_smoother.utils import (
     _validate_inputs,
-    _create_errors,
+    covariance_to_correlation,
     steplength_exponential,
     response_projection,
 )
@@ -116,7 +116,7 @@ class SIES:
 
         E -= E.mean(axis=1, keepdims=True)
 
-        R, observation_errors_std = _create_errors(observation_errors, inversion)
+        R, observation_errors_std = covariance_to_correlation(observation_errors)
 
         # Store D as defined by Equation (14) in Evensen (2019)
         self.D_ = E + observation_values.reshape(num_obs, 1)
@@ -145,8 +145,8 @@ class SIES:
 
         W: npt.NDArray[np.double] = create_coefficient_matrix(  # type: ignore
             _response_ensemble,
-            R,
-            E,
+            R,  # Correlation matrix or None (if 1D array was passed)
+            E,  # Samples from multivariate normal
             D,
             inversion,
             truncation,

--- a/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
+++ b/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
@@ -40,7 +40,13 @@ class SIES:
         self.coefficient_matrix = np.zeros(shape=(ensemble_size, ensemble_size))
         self.rng = np.random.default_rng(seed)
 
-    def _get_E(self, *, observation_errors, observation_values, ensemble_size):
+    def _get_E(
+        self,
+        *,
+        observation_errors: npt.NDArray[np.double],
+        observation_values: npt.NDArray[np.double],
+        ensemble_size: int,
+    ) -> npt.NDArray[np.double]:
         """Draw samples from N(0, Cdd). Use cached values if already drawn."""
 
         # Return cached values if they exist
@@ -67,7 +73,7 @@ class SIES:
         # Center values, removing one degree of freedom
         E -= E.mean(axis=1, keepdims=True)
 
-        self.E_ = E
+        self.E_: npt.NDArray[np.double] = E
         return self.E_
 
     def fit(

--- a/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
+++ b/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
@@ -172,7 +172,7 @@ class SIES:
         # with a diagonal matrix L := sqrt(diag(C_dd)). In an experiment with
         # random covariance matrices, this improved the condition number ~90%
         # of the time (results may depend on how random covariance matrices are
-        # generated --- I covariances C by first E ~ stdnorm(), then C = E.T @ E).
+        # generated --- I generated covariances C as E ~ stdnorm(), then C = E.T @ E).
         # To see the equality, note that if we scale S, E and H := (SW + D - g(X))
         # we obtain:
         #     (L S) (L S)^T + (L E) (L E)^T M_2 = L H
@@ -234,7 +234,7 @@ class SIES:
             np.ix_(self.ensemble_mask, self.ensemble_mask)
         ]
         transition_matrix /= np.sqrt(ensemble_size - 1)
-        transition_matrix.flat[:: ensemble_size + 1] += 1
+        transition_matrix.flat[:: ensemble_size + 1] += 1.0
 
         return param_ensemble @ transition_matrix
 

--- a/src/iterative_ensemble_smoother/experimental.py
+++ b/src/iterative_ensemble_smoother/experimental.py
@@ -7,7 +7,7 @@ import numpy as np
 rng = np.random.default_rng()
 
 from iterative_ensemble_smoother.utils import (
-    _create_errors,
+    covariance_to_correlation,
 )
 
 from iterative_ensemble_smoother.ies import create_coefficient_matrix
@@ -38,7 +38,7 @@ def ensemble_smoother_update_step_row_scaling(
         - np.ones((ensemble_size, ensemble_size)) / ensemble_size
     )
 
-    R, observation_errors = _create_errors(observation_errors, inversion)
+    R, observation_errors = covariance_to_correlation(observation_errors)
 
     D = (E + observation_values.reshape(num_obs, 1)) - response_ensemble
     D = (D.T / observation_errors).T

--- a/src/iterative_ensemble_smoother/ies.py
+++ b/src/iterative_ensemble_smoother/ies.py
@@ -149,7 +149,7 @@ def exact_inversion(W, S, H, steplength):
     C = S.T @ S  # TODO: Only form upper part of this matrix
     # Add the identity matrix in place
     # See: https://github.com/numpy/numpy/blob/db4f43983cb938f12c311e1f5b7165e270c393b4/numpy/lib/index_tricks.py#L786
-    C.flat[:: ensemble_size + 1] += 1.0
+    C.flat[:: ensemble_size + 1] += 1
 
     # Compute term = (S.T @ S + I)^-1 @ S.T @ H
     try:
@@ -251,7 +251,7 @@ def create_coefficient_matrix(Y, R, E, D, inversion, truncation, W, steplength):
         W = W - steplength * (W - X3)
         return W
     elif inversion == "subspace_re":  # Section 3.4 in paper
-        num_observations, ensemble_size = S.shape
+        _, ensemble_size = S.shape
         nsc = 1.0 / np.sqrt(ensemble_size - 1.0)
         eig, X1 = lowrankE(S, E * nsc, truncation)
         # Compute W2 @ diag(lambda_inv) @ W2.T @ H
@@ -305,7 +305,7 @@ def lowrankE(S, E, truncation):
     X0 = (U0 * inv_sigma0).T @ E  # Same as diag(inv_sigma) @ U0.T @ E
 
     # Equation 14.52
-    U1, sigma1, VT1 = sp.linalg.svd(X0, full_matrices=False)
+    U1, sigma1, _ = sp.linalg.svd(X0, full_matrices=False)
 
     # Equation 14.55
     X1 = (U0 * inv_sigma0) @ U1

--- a/src/iterative_ensemble_smoother/ies.py
+++ b/src/iterative_ensemble_smoother/ies.py
@@ -149,7 +149,7 @@ def exact_inversion(W, S, H, steplength):
     C = S.T @ S  # TODO: Only form upper part of this matrix
     # Add the identity matrix in place
     # See: https://github.com/numpy/numpy/blob/db4f43983cb938f12c311e1f5b7165e270c393b4/numpy/lib/index_tricks.py#L786
-    C.flat[:: ensemble_size + 1] += 1
+    C.flat[:: ensemble_size + 1] += 1.0
 
     # Compute term = (S.T @ S + I)^-1 @ S.T @ H
     try:
@@ -237,7 +237,7 @@ def create_coefficient_matrix(Y, R, E, D, inversion, truncation, W, steplength):
         to_invert = S @ S.T + E @ E.T
         K = S.T @ sp.linalg.solve(to_invert, H, assume_a="sym", overwrite_a=True)
         return W - steplength * (W - K)
-    elif inversion == "exact":
+    elif inversion == "exact":  # Section 3.2 in paper
         return exact_inversion(W, S, H, steplength)
 
     # Implements parts of Eq. 14.31 in the book Data Assimilation,

--- a/src/iterative_ensemble_smoother/ies.py
+++ b/src/iterative_ensemble_smoother/ies.py
@@ -188,7 +188,7 @@ def create_coefficient_matrix(Y, R, E, D, inversion, truncation, W, steplength):
     array([[0.76348548, 0.63347165],
            [1.94605809, 1.79944675]])
 
-    Diagonal corvariane matrix:
+    Diagonal covariance matrix:
 
     >>> R = np.eye(2)
     >>> E = np.eye(2)
@@ -210,10 +210,7 @@ def create_coefficient_matrix(Y, R, E, D, inversion, truncation, W, steplength):
 
     # Add the identity matrix in place
     # See: https://github.com/numpy/numpy/blob/db4f43983cb938f12c311e1f5b7165e270c393b4/numpy/lib/index_tricks.py#L786
-    Omega.flat[: ensemble_size * ensemble_size : ensemble_size + 1] += 1
-
-    # Omega.transposeInPlace();
-    # MatrixXd S = Omega.fullPivLu().solve(Y.transpose()).transpose();
+    Omega.flat[: ensemble_size * ensemble_size : ensemble_size + 1] += 1.0
 
     # Line 6 of Algorithm 1, also Section 5
     # Solving for the average sensitivity matrix.
@@ -242,10 +239,28 @@ def create_coefficient_matrix(Y, R, E, D, inversion, truncation, W, steplength):
         return W - steplength * (W - K)
     elif inversion == "exact":
         return exact_inversion(W, S, H, steplength)
-    else:
-        return subspace_inversion(W, S, E, H, truncation, inversion, steplength, R=R)
 
-    return None
+    # Implements parts of Eq. 14.31 in the book Data Assimilation,
+    # The Ensemble Kalman Filter, 2nd Edition by Geir Evensen.
+
+    elif inversion == "exact_r":  # Section 3.3 in paper
+        eig, X1 = lowrankCinv(S, R, truncation)
+        # Compute W2 @ diag(lambda_inv) @ W2.T @ H
+        X3 = np.linalg.multi_dot([S.T, X1 * eig, X1.T, H])
+        # Line 9 in algorithm 1
+        W = W - steplength * (W - X3)
+        return W
+    elif inversion == "subspace_re":  # Section 3.4 in paper
+        num_observations, ensemble_size = S.shape
+        nsc = 1.0 / np.sqrt(ensemble_size - 1.0)
+        eig, X1 = lowrankE(S, E * nsc, truncation)
+        # Compute W2 @ diag(lambda_inv) @ W2.T @ H
+        X3 = np.linalg.multi_dot([S.T, X1 * eig, X1.T, H])
+        # Line 9 in algorithm 1
+        W = W - steplength * (W - X3)
+        return W
+    else:
+        raise Exception(f"Invalid inversion {inversion}")
 
 
 def lowrankE(S, E, truncation):
@@ -342,7 +357,12 @@ def lowrankCinv(S, R, truncation):
 
     # Equation (14.26)
     U0_inv_sigma = U0 * inv_sig0
-    X0 = np.linalg.multi_dot([U0_inv_sigma.T, R, U0_inv_sigma])
+
+    # If a 1D array was passed for covariance, then R (correlation matrix) is None
+    if R is None:
+        X0 = U0_inv_sigma.T @ U0_inv_sigma
+    else:
+        X0 = np.linalg.multi_dot([U0_inv_sigma.T, R, U0_inv_sigma])
 
     U1, sig, _ = sp.linalg.svd(X0, full_matrices=False)
 
@@ -352,30 +372,6 @@ def lowrankCinv(S, R, truncation):
     # Equation (14.29)
     eig = 1 / (1 + sig)
     return eig, X1
-
-
-def subspace_inversion(W, S, E, H, truncation, inversion, steplength, R=None):
-    assert inversion in ("exact_r", "subspace_re")
-
-    num_observations, ensemble_size = S.shape
-    nsc = 1.0 / np.sqrt(ensemble_size - 1.0)
-
-    if inversion == "subspace_re":  # Section 3.4 in paper
-        eig, X1 = lowrankE(S, E * nsc, truncation)
-    elif inversion == "exact_r":  # # Section 3.3 in paper
-        eig, X1 = lowrankCinv(S, R, truncation)
-    else:
-        raise Exception(f"Invalid inversion {inversion}")
-
-    # Implements parts of Eq. 14.31 in the book Data Assimilation,
-    # The Ensemble Kalman Filter, 2nd Edition by Geir Evensen.
-
-    # Compute W2 @ diag(lambda_inv) @ W2.T @ H
-    X3 = np.linalg.multi_dot([S.T, X1 * eig, X1.T, H])
-
-    # Line 9 in algorithm 1
-    W = W - steplength * (W - X3)
-    return W
 
 
 if __name__ == "__main__":

--- a/src/iterative_ensemble_smoother/utils.py
+++ b/src/iterative_ensemble_smoother/utils.py
@@ -66,23 +66,11 @@ def response_projection(
     A = param_ensemble - param_ensemble.mean(axis=1, keepdims=True)
     A /= np.sqrt(ensemble_size - 1)
 
-    # The code below is equivalent to np.linalg.pinv(A) @ A, since:
-    # pinv(A) @ A = [V (1/s) U.T] @ [U s V.T]
-    #             = V (1/s) @ s V.T
-
-    # Compute SVD
-    U, s, VT = sp.linalg.svd(A, full_matrices=False)
-
-    # This code is adapted from
-    # https://github.com/numpy/numpy/blob/db4f43983cb938f12c311e1f5b7165e270c393b4/numpy/linalg/linalg.py#L2015
-    rcond = np.asarray(1e-15)
-    cutoff = rcond[..., np.newaxis] * np.amax(s, axis=-1, keepdims=True)
-
-    # Only keep columns in V corresponding to "large" singular values
-    VT_filtered = VT[(s > cutoff), :]
-
-    projection: npt.NDArray[np.double] = VT_filtered.T @ VT_filtered
-    return projection
+    # TODO: Since pinv(A) takes the SVD, it seems like using the SVD directly
+    # to compute pinv(A) @ A directly without forming pinv(A) explicitly should
+    # be faster, but a quick timing showed no such result. Might be worth
+    # looking into.
+    return np.linalg.pinv(A) @ A
 
 
 def _validate_inputs(

--- a/src/iterative_ensemble_smoother/utils.py
+++ b/src/iterative_ensemble_smoother/utils.py
@@ -53,6 +53,14 @@ def response_projection(
     array([[ 0.5,  0. , -0.5],
            [ 0. ,  0. ,  0. ],
            [-0.5,  0. ,  0.5]])
+
+    Equivalent to:
+
+    >>> C = (A - A.mean(axis=1, keepdims=True)) / np.sqrt(3 - 1)
+    >>> np.linalg.pinv(C) @ C
+    array([[ 0.5,  0. , -0.5],
+           [ 0. ,  0. ,  0. ],
+           [-0.5,  0. ,  0.5]])
     """
     ensemble_size = param_ensemble.shape[1]
     A = param_ensemble - param_ensemble.mean(axis=1, keepdims=True)

--- a/src/iterative_ensemble_smoother/utils.py
+++ b/src/iterative_ensemble_smoother/utils.py
@@ -70,7 +70,8 @@ def response_projection(
     # to compute pinv(A) @ A directly without forming pinv(A) explicitly should
     # be faster, but a quick timing showed no such result. Might be worth
     # looking into.
-    return np.linalg.pinv(A) @ A
+    ans: npt.NDArray[np.double] = np.linalg.pinv(A) @ A
+    return ans
 
 
 def _validate_inputs(

--- a/src/iterative_ensemble_smoother/utils.py
+++ b/src/iterative_ensemble_smoother/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import Tuple, Optional, TYPE_CHECKING
 
 import numpy as np
+import scipy as sp
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -44,12 +45,35 @@ def response_projection(
 ) -> npt.NDArray[np.double]:
     """A^+A projection is necessary when the parameter matrix has fewer rows than
     columns, and when the forward model is non-linear. Section 2.4.3
+
+    Examples
+    --------
+    >>> A = np.arange(9, dtype=float).reshape(3,3)
+    >>> response_projection(A)
+    array([[ 0.5,  0. , -0.5],
+           [ 0. ,  0. ,  0. ],
+           [-0.5,  0. ,  0.5]])
     """
     ensemble_size = param_ensemble.shape[1]
-    A = (param_ensemble - param_ensemble.mean(axis=1, keepdims=True)) / np.sqrt(
-        ensemble_size - 1
-    )
-    projection: npt.NDArray[np.double] = np.linalg.pinv(A) @ A
+    A = param_ensemble - param_ensemble.mean(axis=1, keepdims=True)
+    A /= np.sqrt(ensemble_size - 1)
+
+    # The code below is equivalent to np.linalg.pinv(A) @ A, since:
+    # pinv(A) @ A = [V (1/s) U.T] @ [U s V.T]
+    #             = V (1/s) @ s V.T
+
+    # Compute SVD
+    U, s, VT = sp.linalg.svd(A, full_matrices=False)
+
+    # This code is adapted from
+    # https://github.com/numpy/numpy/blob/db4f43983cb938f12c311e1f5b7165e270c393b4/numpy/linalg/linalg.py#L2015
+    rcond = np.asarray(1e-15)
+    cutoff = rcond[..., np.newaxis] * np.amax(s, axis=-1, keepdims=True)
+
+    # Only keep columns in V corresponding to "large" singular values
+    VT_filtered = VT[(s > cutoff), :]
+
+    projection: npt.NDArray[np.double] = VT_filtered.T @ VT_filtered
     return projection
 
 
@@ -106,21 +130,51 @@ def _validate_inputs(
         )
 
 
-def _create_errors(
-    observation_errors: npt.NDArray[np.double],
-    inversion: str,
+def covariance_to_correlation(
+    C: npt.NDArray[np.double],
 ) -> Tuple[npt.NDArray[np.double], npt.NDArray[np.double]]:
-    if observation_errors.ndim == 2:
-        R = observation_errors
-        observation_errors = np.sqrt(observation_errors.diagonal())
-        # The line below is equivalent to:
-        # R = np.diag(1 / observation_errors) @ R @ np.diag(1 / observation_errors)
-        R = R * np.outer(1 / observation_errors, 1 / observation_errors)
+    """The input C is either (1) a 2D covariance matrix or (2) a 1D array of
+    standard deviations. This function normalizes the covariance matrix to a
+    correlation matrix (unit diagonal).
 
-    elif observation_errors.ndim == 1 and inversion == "exact_r":
-        R = np.identity(len(observation_errors))
+    Examples
+    --------
+    >>> C = np.array([[4., 1., 0.],
+    ...               [1., 4., 1.],
+    ...               [0., 1., 4.]])
+    >>> corr_mat, stds = covariance_to_correlation(C)
+    >>> corr_mat
+    array([[1.  , 0.25, 0.  ],
+           [0.25, 1.  , 0.25],
+           [0.  , 0.25, 1.  ]])
+    >>> stds
+    array([2., 2., 2.])
+    """
 
-    else:
-        R = None
+    # A covariance matrix was passed
+    if C.ndim == 2:
+        standard_deviations = np.sqrt(C.diagonal())
 
-    return R, observation_errors
+        # Create a correlation matrix from a covariance matrix
+        # https://en.wikipedia.org/wiki/Covariance_matrix#Relation_to_the_correlation_matrix
+
+        # Divide every column
+        correlation_matrix = C / standard_deviations.reshape(1, -1)
+
+        # Divide every row
+        correlation_matrix /= standard_deviations.reshape(-1, 1)
+
+        return correlation_matrix, standard_deviations
+
+    # A vector of standard deviations was passed
+    if C.ndim == 1:
+        correlation_matrix = None
+        standard_deviations = C
+        return None, standard_deviations
+
+
+if __name__ == "__main__":
+    import pytest
+
+    # --durations=10  <- May be used to show potentially slow tests
+    pytest.main(args=[__file__, "--doctest-modules", "-v", "-v"])

--- a/src/iterative_ensemble_smoother/utils.py
+++ b/src/iterative_ensemble_smoother/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Tuple, Optional, TYPE_CHECKING
 
 import numpy as np
-import scipy as sp
+import scipy as sp  # type: ignore
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -132,7 +132,7 @@ def _validate_inputs(
 
 def covariance_to_correlation(
     C: npt.NDArray[np.double],
-) -> Tuple[npt.NDArray[np.double], npt.NDArray[np.double]]:
+) -> Tuple[Optional[npt.NDArray[np.double]], npt.NDArray[np.double]]:
     """The input C is either (1) a 2D covariance matrix or (2) a 1D array of
     standard deviations. This function normalizes the covariance matrix to a
     correlation matrix (unit diagonal).
@@ -150,6 +150,7 @@ def covariance_to_correlation(
     >>> stds
     array([2., 2., 2.])
     """
+    assert isinstance(C, np.ndarray) and C.ndim in (1, 2)
 
     # A covariance matrix was passed
     if C.ndim == 2:
@@ -167,10 +168,9 @@ def covariance_to_correlation(
         return correlation_matrix, standard_deviations
 
     # A vector of standard deviations was passed
-    if C.ndim == 1:
-        correlation_matrix = None
-        standard_deviations = C
-        return None, standard_deviations
+    correlation_matrix = None
+    standard_deviations = C
+    return None, standard_deviations
 
 
 if __name__ == "__main__":

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -19,7 +19,6 @@ class LinearModel:
     def __init__(self, a, b):
         self.a = a
         self.b = b
-        self.size = 2
 
     @classmethod
     def random(cls):


### PR DESCRIPTION
Some houesekeeping on IES:


- Renamed `_create_errors` to `covariance_to_correlation`. Wrote a docstring for it. Wrote some doctests for it. Removed redundant arg `inversion`
- Removed generation of `E` (samples from covariance) to it's own method. This closes #115
- Wrote a long comment about rescaling the covariance matrix to a correlation matrix, since there was no comments regarding this and it's not mentioned in the paper
- Renamed `iteration_nr` to `iteration`

Some of these changes are a bit subjective, so I am open to discussion.