### PR TITLE
Removed `ensemble_size` argument from SIES

### DIFF
--- a/docs/source/Oscillator.py
+++ b/docs/source/Oscillator.py
@@ -133,14 +133,13 @@ plot_result(new_A, response_x_axis, uniform, priors)
 
 # %%
 import numpy as np
-from matplotlib import pyplot as plt
 import iterative_ensemble_smoother as ies
 
 
 def iterative_smoother():
     A_current = np.copy(A)
     iterations = 4
-    smoother = ies.SIES(realizations)
+    smoother = ies.SIES(seed=42)
 
     for _ in range(iterations):
         plot_result(A_current, response_x_axis, uniform, priors)
@@ -160,7 +159,6 @@ iterative_smoother()
 
 # %%
 import numpy as np
-from matplotlib import pyplot as plt
 import iterative_ensemble_smoother as ies
 
 

--- a/docs/source/Polynomial.py
+++ b/docs/source/Polynomial.py
@@ -135,7 +135,7 @@ X_ES_ert = smoother_es.update(X_ES_ert)
 
 X_IES_ert = X.copy()
 Y_IES_ert = Y.copy()
-smoother_ies = ies.SIES(ensemble_size=ensemble_size, seed=42)
+smoother_ies = ies.SIES(seed=42)
 n_ies_iter = 7
 for i in range(n_ies_iter):
     smoother_ies.fit(Y_IES_ert, d.sd.values, d.value.values)

--- a/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
+++ b/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
@@ -27,6 +27,7 @@ class SIES:
 
     def __init__(
         self,
+        *,
         steplength_schedule: Optional[Callable[[int], float]] = None,
         seed: Optional[int] = None,
     ):
@@ -179,7 +180,7 @@ class SIES:
         return param_ensemble @ transition_matrix
 
     def __repr__(self) -> str:
-        return f"SIES()"
+        return "SIES()"
 
 
 class ES:

--- a/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
+++ b/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
@@ -27,15 +27,11 @@ class SIES:
 
     def __init__(
         self,
-        ensemble_size: int,
-        *,
         steplength_schedule: Optional[Callable[[int], float]] = None,
         seed: Optional[int] = None,
     ):
-        self._initial_ensemble_size = ensemble_size
         self.iteration_nr = 1
         self.steplength_schedule = steplength_schedule
-        self.coefficient_matrix = np.zeros(shape=(ensemble_size, ensemble_size))
         self.seed = seed
 
     def fit(
@@ -93,6 +89,10 @@ class SIES:
                 step_length = self.steplength_schedule(self.iteration_nr)
 
         assert 0 < step_length <= 1, "Step length must be in (0, 1]"
+
+        # If it's the first time the method is called, create coeff matrix
+        if not hasattr(self, "coefficient_matrix"):
+            self.coefficient_matrix = np.zeros(shape=(ensemble_size, ensemble_size))
 
         # Seed here so we draw the same samples in every iteration (call to update())
         rng = np.random.default_rng(self.seed)
@@ -179,7 +179,7 @@ class SIES:
         return param_ensemble @ transition_matrix
 
     def __repr__(self) -> str:
-        return f"SIES(ensemble_size={self._initial_ensemble_size})"
+        return f"SIES()"
 
 
 class ES:
@@ -200,7 +200,7 @@ class ES:
         inversion: str = "exact",
         param_ensemble: Optional[npt.NDArray[np.double]] = None,
     ) -> None:
-        self.smoother = SIES(ensemble_size=response_ensemble.shape[1], seed=self.seed)
+        self.smoother = SIES(seed=self.seed)
         self.smoother.fit(
             response_ensemble,
             observation_errors,

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -29,7 +29,7 @@ def test_that_bad_inputs_cause_nice_error_messages():
             "response_ensemble must be a matrix of size (number of responses by number of realizations)"
         ),
     ):
-        _ = SIES(ensemble_size).fit(Y.ravel(), obs_errors, obs_values)
+        _ = SIES().fit(Y.ravel(), obs_errors, obs_values)
 
     with pytest.raises(
         ValueError,
@@ -37,7 +37,7 @@ def test_that_bad_inputs_cause_nice_error_messages():
             "observation_errors and observation_values must have the same number of elements"
         ),
     ):
-        _ = SIES(ensemble_size).fit(Y, obs_errors[1:], obs_values)
+        _ = SIES().fit(Y, obs_errors[1:], obs_values)
 
     with pytest.raises(
         ValueError,
@@ -45,13 +45,13 @@ def test_that_bad_inputs_cause_nice_error_messages():
             "observation_values must have the same number of elements as there are responses"
         ),
     ):
-        _ = SIES(ensemble_size).fit(Y, obs_errors[1:], obs_values[1:])
+        _ = SIES().fit(Y, obs_errors[1:], obs_values[1:])
 
     with pytest.raises(
         ValueError,
         match="param_ensemble and response_ensemble must have the same number of columns",
     ):
-        _ = SIES(ensemble_size).fit(
+        _ = SIES().fit(
             Y,
             obs_errors,
             obs_values,
@@ -64,7 +64,7 @@ def test_that_bad_inputs_cause_nice_error_messages():
             "parameter_ensemble must be a matrix of size (number of parameters by number of realizations)"
         ),
     ):
-        _ = SIES(ensemble_size).fit(
+        _ = SIES().fit(
             Y,
             obs_errors,
             obs_values,

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -5,7 +5,7 @@ import re
 
 
 def test_that_repr_can_be_created():
-    smoother = SIES(100)
+    smoother = SIES()
     smoother_repr = eval(repr(smoother))
     assert isinstance(smoother_repr, SIES)
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -86,7 +86,7 @@ def test_that_projection_is_better_for_nonlinear_forward_model_big_N_small_n(N):
 
     seed = 123
     # find solutions with and without projection
-    model_projection = ies.SIES(N, seed=seed)
+    model_projection = ies.SIES(seed=seed)
     model_projection.fit(
         gX,
         d_sd,
@@ -97,7 +97,7 @@ def test_that_projection_is_better_for_nonlinear_forward_model_big_N_small_n(N):
     )
     X_posterior_projection = model_projection.update(X_prior)
 
-    model_no_projection = ies.SIES(N, seed=seed)
+    model_no_projection = ies.SIES(seed=seed)
     model_no_projection.fit(
         gX,
         d_sd,
@@ -294,7 +294,7 @@ def test_that_sies_converges_to_es_in_gauss_linear_case():
 
     params_ies = X.copy()
     responses_ies = response_ensemble.copy()
-    smoother_ies = ies.SIES(ensemble_size, seed=seed)
+    smoother_ies = ies.SIES(seed=seed)
     for _ in range(10):
         smoother_ies.fit(responses_ies, d.sd.values, d.value.values)
         params_ies = smoother_ies.update(params_ies)
@@ -368,7 +368,7 @@ def test_that_update_correctly_multiples_gaussians(inversion, errors):
 
     obs_val = 10
     observation_values = np.array([obs_val, obs_val, obs_val])
-    smoother = ies.SIES(N)
+    smoother = ies.SIES(seed=42)
 
     smoother.fit(
         Y,
@@ -468,7 +468,7 @@ def test_that_ies_runs_with_failed_realizations():
     obs_errors = 0.01 + np.abs(rng.normal(size=num_responses))  # Stds must be positive
     ens_mask = np.array([True] * ensemble_size)
     ens_mask[10:] = False
-    smoother = ies.SIES(ensemble_size)
+    smoother = ies.SIES(seed=42)
     smoother.fit(
         response_ensemble[:, ens_mask],
         obs_errors,

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -514,7 +514,7 @@ def test_that_diagonal_and_dense_covariance_return_the_same_result(inversion, se
     observation_errors_cov_mat = np.diag(observation_errors_diag_std**2)
 
     # 1D array of standard deviations
-    smoother_diag = ies.SIES(ensemble_size=ensemble_size, seed=1)
+    smoother_diag = ies.SIES(seed=1)
     assert observation_errors_diag_std.ndim == 1
     smoother_diag.fit(
         response_ensemble=response_ensemble,
@@ -526,7 +526,7 @@ def test_that_diagonal_and_dense_covariance_return_the_same_result(inversion, se
     X_post_diag = smoother_diag.update(param_ensemble)
 
     # 2D array of covariances (covariance matrix)
-    smoother_covar = ies.SIES(ensemble_size=ensemble_size, seed=1)
+    smoother_covar = ies.SIES(seed=1)
     assert observation_errors_cov_mat.ndim == 2
     smoother_covar.fit(
         response_ensemble=response_ensemble,

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -119,7 +119,7 @@ def test_iterative_ensemble_smoother_update_step(snapshot, initial_A, initial_S)
     # performing an update step gives us a new A matrix with updated parameters
     # for the ensemble
     seed = 12345
-    smoother = ies.SIES(ensemble_size=initial_A.shape[1], seed=seed)
+    smoother = ies.SIES(seed=seed)
     smoother.fit(
         initial_S,
         observation_errors,
@@ -156,8 +156,7 @@ def test_ensemble_smoother_update_step(snapshot, initial_A, initial_S):
     # performing an update step gives us a new A matrix with updated parameters
     # for the ensemble
     seed = 12345
-    ensemble_size = initial_A.shape[1]
-    smoother = ies.SIES(ensemble_size, seed=seed)
+    smoother = ies.SIES(seed=seed)
     smoother.fit(
         initial_S,
         observation_errors,


### PR DESCRIPTION
The `ensemble_size` argument is used to set up the coefficient matrix. But there is no need to set it up during initialization. If we set it up on the first `fit` call instead, we don't need the argument at all, since we can deduce the ensemble size from the other arguments sent to `fit`.

This makes life easier for users. I also think it's a good principle to not include multiple input arguments if some can be deduced from others.

What do you think?

**Warning: Breaking public API change**