### PR TITLE
IMP: add ruff and codespell  to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,20 @@ repos:
                 ^docs
             )
         args: [--strict, --ignore-missing-imports, --no-warn-unused-ignores]
+
+-   repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
+    hooks:
+    -   id: codespell
+        files: ^.*\.(py|c|h|md|rst|yml)$
+        args: [
+        "docs tests",
+        "*.py *.rst *.md",
+        ]
+
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.0.289
+    hooks:
+    -   id: ruff
+        args: [--fix, --exit-non-zero-on-fix]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Iterative Ensemble Smoother
 ===========================
 
+[![Precommit: enabled](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![docs](https://readthedocs.org/projects/iterative_ensemble_smoother/badge/?version=latest&style=plastic)](https://iterative-ensemble-smoother.readthedocs.io/)
 

--- a/docs/source/Oscillator.py
+++ b/docs/source/Oscillator.py
@@ -12,13 +12,14 @@
 #     language: python
 #     name: python3
 # ---
-
+# ruff: noqa: E402
 # %% [markdown]
 # # Estimating parameters of an anharmonic oscillator
 #
 # The anharnomic oscillator can be modelled by a non-linear partial differential
 # equation as described in section 6.3.4 of the book [Fundamentals of Algorithms
-# and Data Assimilation](https://www.amazon.com/Data-Assimilation-Methods-Algorithms-Applications/dp/1611974534) by Mark Asch, Marc Bocquet and Maëlle Nodet.
+# and Data Assimilation](https://www.amazon.com/Data-Assimilation-Methods-Algorithms-Applications/dp/1611974534)
+# by Mark Asch, Marc Bocquet and Maëlle Nodet.
 #
 # -------------
 #
@@ -53,11 +54,11 @@
 #
 #
 
-# %%
-from matplotlib import pyplot as plt
+#%%
 import numpy as np
+from matplotlib import pyplot as plt
 from scipy import stats
-from scipy.special import erf
+
 import iterative_ensemble_smoother as ies
 
 rng = np.random.default_rng(12345)
@@ -168,7 +169,7 @@ plt.show()
 # The trick is to sample $x \sim \mathcal{N}(0, 1)$,
 # then define a function $f$ that maps from standard normal to the
 # exponential distribution.
-# This funciton can be constructed by first mapping from standard normal to
+# This function can be constructed by first mapping from standard normal to
 # the interval $[0, 1)$ using the CDF, then mapping to exponential using the
 # quantile function (inverse CDF) of the exponential distribution.
 #

--- a/docs/source/Polynomial.py
+++ b/docs/source/Polynomial.py
@@ -12,16 +12,21 @@
 #     language: python
 #     name: python3
 # ---
+# ruff: noqa: E402
+# ruff: noqa: E501
 
 # %% [markdown]
 # # Fitting a polynomial with Gaussian priors
 #
-# We fit a simple polynomial with Gaussian priors, which is an example of a Gauss-linear problem for which the results obtained using Subspace Iterative Ensemble Smoother (SIES) tend to those obtained using Ensemble Smoother (ES).
+# We fit a simple polynomial with Gaussian priors, which is an example of a Gauss-linear
+# problem for which the results obtained using Subspace Iterative Ensemble Smoother
+# (SIES) tend to those obtained using Ensemble Smoother (ES).
 # This notebook illustrated this property.
 # %%
+import itertools
+
 import numpy as np
 import pandas as pd
-import itertools
 
 np.set_printoptions(suppress=True)
 rng = np.random.default_rng(12345)
@@ -32,9 +37,8 @@ COLORS = list(plt.rcParams["axes.prop_cycle"].by_key()["color"])
 
 plt.rcParams["figure.figsize"] = (6, 6)
 plt.rcParams.update({"font.size": 10})
-from ipywidgets import interact
-import ipywidgets as widgets
-
+from ipywidgets import interact  # noqa  # isort:skip
+import ipywidgets as widgets  # noqa  # isort:skip
 from p_tqdm import p_map
 
 import iterative_ensemble_smoother as ies
@@ -112,7 +116,7 @@ fwd_runs = p_map(
     coeff_b,
     coeff_c,
     [np.arange(max(x_observations) + 1)] * ensemble_size,
-    desc=f"Running forward model.",
+    desc="Running forward model.",
 )
 
 # %% [markdown]
@@ -228,7 +232,7 @@ for parameter_prior in X.T:
     )
 
 # Plot the posterior
-ax2.set_title(f"ES ert posterior")
+ax2.set_title("ES ert posterior")
 ax2.plot(x_plot, poly(a_t, b_t, c_t, x_plot), zorder=10, lw=4, color="black")
 for parameter_posterior in X_ES_ert.T:
     ax2.plot(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,56 @@ write_to = "src/iterative_ensemble_smoother/_version.py"
 testpaths = [
     "tests"
 ]
+
+[tool.ruff]
+select = [
+    # Pyflakes
+    "F",
+    # Pycodestyle
+    "E",
+    "W",
+    # isort
+    "I"
+]
+src = ["src", "tests", "docs"]
+
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+fixable = ["A", "B", "C", "D", "E", "F", "I"]
+unfixable = []
+
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+]
+
+# Same as Black.
+line-length = 88
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+# Assume Python 3.10.
+target-version = "py310"
+
+[tool.ruff.mccabe]
+# Unlike Flake8, default to a complexity level of 10.
+max-complexity = 10

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,9 @@
-[flake8]
-ignore = E302, W503, E501, E741, E203, F405
-max-line-length = 88
+[codespell]
+skip = *.pyc,*.gif,*.png,*.jpg,*.ply, ./bibliography.bib,*.ipynb
+ignore-words-list = lod,byteorder,flem,parm,doubleclick,revered,inout,fro,nd,sies,hist,ans
+quiet-level = 3
+
+[pylint.LOGGING]
+# Format style used to check logging format string. `old` means using %
+# formatting, `new` is for `{}` formatting,and `fstr` is for f-strings.
+logging-format-style=fstr

--- a/src/iterative_ensemble_smoother/__init__.py
+++ b/src/iterative_ensemble_smoother/__init__.py
@@ -9,6 +9,7 @@ try:
 except ImportError:
     __version__ = "unknown version"
     version_tuple = (0, 0, "unknown version", "unknown commit")
+
 from iterative_ensemble_smoother._iterative_ensemble_smoother import ES, SIES
 from iterative_ensemble_smoother.esmda import ESMDA
 

--- a/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
+++ b/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
-from typing import Optional, TYPE_CHECKING, Callable
+
+from typing import TYPE_CHECKING, Callable, Optional
 
 import numpy as np
 
 if TYPE_CHECKING:
     import numpy.typing as npt
 
+from iterative_ensemble_smoother.ies import create_coefficient_matrix
 from iterative_ensemble_smoother.utils import (
     _validate_inputs,
     covariance_to_correlation,
-    steplength_exponential,
     response_projection,
+    steplength_exponential,
 )
-
-from iterative_ensemble_smoother.ies import create_coefficient_matrix
 
 
 class SIES:
@@ -21,12 +21,14 @@ class SIES:
     Initialize a Subspace Iterative Ensemble Smoother (SIES) instance.
 
     This is an implementation of the algorithm described in the paper:
-    Efficient Implementation of an Iterative Ensemble Smoother for Data Assimilation and Reservoir History Matching
-    written by Evensen et al (2019), URL: https://www.frontiersin.org/articles/10.3389/fams.2019.00047/full
+    Efficient Implementation of an Iterative Ensemble Smoother for Data Assimilation
+    and Reservoir History Matching written by Evensen et al (2019),
+    URL: https://www.frontiersin.org/articles/10.3389/fams.2019.00047/full
 
     The default step length is described in equation (49) in the paper
     Formulating the history matching problem with consistent error statistics
-    written by Geir Evensen (2021), URL: https://link.springer.com/article/10.1007/s10596-021-10032-7
+    written by Geir Evensen (2021),
+    URL: https://link.springer.com/article/10.1007/s10596-021-10032-7
 
     Parameters
     ----------
@@ -110,7 +112,8 @@ class SIES:
         Parameters
         ----------
         response_ensemble : npt.NDArray[np.double]
-            A 2D array of reponses from the model g(X) of shape (observations, ensemble_size).
+            A 2D array of responses from the model g(X) of shape
+            (observations, ensemble_size).
             This matrix is Y in Evensen (2019).
         observation_errors : npt.NDArray[np.double]
             Either a 1D array of standard deviations, or a 2D covariance matrix.
@@ -254,7 +257,8 @@ class SIES:
 
         if np.isnan(W).sum() != 0:
             raise ValueError(
-                "Fit produces NaNs. Check your response matrix for outliers or use an inversion type with truncation."
+                "Fit produces NaNs. Check your response matrix for outliers "
+                "or use an inversion type with truncation."
             )
 
         self.iteration += 1

--- a/src/iterative_ensemble_smoother/esmda.py
+++ b/src/iterative_ensemble_smoother/esmda.py
@@ -21,7 +21,6 @@ https://gitlab.com/antoinecollet5/pyesmda
 https://helper.ipam.ucla.edu/publications/oilws3/oilws3_14147.pdf
 
 """
-
 import numbers
 from typing import Optional, Union
 
@@ -106,16 +105,19 @@ class ESMDA:
             isinstance(seed, (int, np.random._generator.Generator)) or seed is None
         ):
             raise TypeError(
-                "Argument `seed` must be an integer or numpy.random._generator.Generator."
+                "Argument `seed` must be an integer "
+                "or numpy.random._generator.Generator."
             )
 
         if not isinstance(inversion, str):
             raise TypeError(
-                f"Argument `inversion` must be a string in {tuple(self._inversion_methods.keys())}"
+                "Argument `inversion` must be a string in "
+                f"{tuple(self._inversion_methods.keys())}"
             )
         if inversion not in self._inversion_methods.keys():
             raise ValueError(
-                f"Argument `inversion` must be a string in {tuple(self._inversion_methods.keys())}"
+                "Argument `inversion` must be a string in "
+                f"{tuple(self._inversion_methods.keys())}"
             )
 
         # Store data

--- a/src/iterative_ensemble_smoother/esmda_inversion.py
+++ b/src/iterative_ensemble_smoother/esmda_inversion.py
@@ -135,8 +135,10 @@ def singular_values_to_keep(
 #
 #  C_MD @ inv(C_DD + alpha * C_D) @ (D - Y)
 #
-# where C_MD = empirical_cross_covariance(X, Y) = center(X) @ center(Y).T / (X.shape[1] - 1)
-#       C_DD = empirical_cross_covariance(Y, Y) = center(Y) @ center(Y).T / (Y.shape[1] - 1)
+# where C_MD = empirical_cross_covariance(X, Y) =
+# center(X) @ center(Y).T / (X.shape[1] - 1)
+#       C_DD = empirical_cross_covariance(Y, Y) =
+# center(Y) @ center(Y).T / (Y.shape[1] - 1)
 #
 # The methods can be classified as
 #   - exact : with truncation=1.0, these methods compute the exact solution
@@ -312,7 +314,9 @@ def inversion_exact_rescaled(
     X_shift = (X - np.mean(X, axis=1, keepdims=True)) / (N_e - 1)
     Y_shift = Y - np.mean(Y, axis=1, keepdims=True)
 
-    return np.linalg.multi_dot([X_shift, Y_shift.T, term / s_r, term.T, (D - Y)])  # type: ignore
+    return np.linalg.multi_dot(  # type: ignore
+        [X_shift, Y_shift.T, term / s_r, term.T, (D - Y)]
+    )
 
 
 def inversion_exact_subspace_woodbury(
@@ -339,7 +343,8 @@ def inversion_exact_subspace_woodbury(
 
     """
 
-    # Woodbury: (A + U @ U.T)^-1 = A^-1 - A^-1 @ U @ (1 + U.T @ A^-1 @ U )^-1 @ U.T @ A^-1
+    # Woodbury:
+    # (A + U @ U.T)^-1 = A^-1 - A^-1 @ U @ (1 + U.T @ A^-1 @ U )^-1 @ U.T @ A^-1
 
     # Compute D_delta. N_n = number of outputs, N_e = number of ensemble members
     N_n, N_e = Y.shape
@@ -364,7 +369,9 @@ def inversion_exact_subspace_woodbury(
 
         # Compute the woodbury inversion, then return
         inverted = C_D_inv - np.linalg.multi_dot([term, sp.linalg.inv(center), term.T])
-        return np.linalg.multi_dot([X_shift, D_delta.T, inverted, (D - Y)])  # type: ignore
+        return np.linalg.multi_dot(  # type: ignore
+            [X_shift, D_delta.T, inverted, (D - Y)]
+        )
 
     # A diagonal covariance matrix was given as a 1D array.
     # Same computation as above, but exploit the diagonal structure
@@ -376,7 +383,9 @@ def inversion_exact_subspace_woodbury(
         inverted = np.diag(C_D_inv) - np.linalg.multi_dot(
             [UT_D.T, sp.linalg.inv(center), UT_D]
         )
-        return np.linalg.multi_dot([X_shift, D_delta.T, inverted, (D - Y)])  # type: ignore
+        return np.linalg.multi_dot(  # type: ignore
+            [X_shift, D_delta.T, inverted, (D - Y)]
+        )
 
 
 def inversion_subspace(
@@ -461,7 +470,9 @@ def inversion_subspace(
 
     # Compute C_MD = center(X) @ center(Y).T / (num_ensemble - 1)
     X_shift = X - np.mean(X, axis=1, keepdims=True)
-    return np.linalg.multi_dot([X_shift, D_delta.T, (term / (1 + T)), term.T, (D - Y)])  # type: ignore
+    return np.linalg.multi_dot(  # type: ignore
+        [X_shift, D_delta.T, (term / (1 + T)), term.T, (D - Y)]
+    )
 
 
 def inversion_rescaled_subspace(
@@ -520,7 +531,9 @@ def inversion_rescaled_subspace(
 
     # Compute C_MD
     X_shift = X - np.mean(X, axis=1, keepdims=True)
-    return np.linalg.multi_dot([X_shift, D_delta.T, (term * diag), term.T, (D - Y)])  # type: ignore
+    return np.linalg.multi_dot(  # type: ignore
+        [X_shift, D_delta.T, (term * diag), term.T, (D - Y)]
+    )
 
 
 if __name__ == "__main__":

--- a/src/iterative_ensemble_smoother/experimental.py
+++ b/src/iterative_ensemble_smoother/experimental.py
@@ -4,13 +4,10 @@ features of iterative_ensemble_smoother
 """
 import numpy as np
 
-rng = np.random.default_rng()
-
-from iterative_ensemble_smoother.utils import (
-    covariance_to_correlation,
-)
-
 from iterative_ensemble_smoother.ies import create_coefficient_matrix
+from iterative_ensemble_smoother.utils import covariance_to_correlation
+
+rng = np.random.default_rng()
 
 
 def ensemble_smoother_update_step_row_scaling(
@@ -56,7 +53,7 @@ def ensemble_smoother_update_step_row_scaling(
             np.zeros((ensemble_size, ensemble_size)),
             1.0,
         )
-        I = np.identity(ensemble_size)
+        I = np.identity(ensemble_size)  # noqa: E741
         transition_matrix = I + W / np.sqrt(ensemble_size - 1)
         row_scale.multiply(A, transition_matrix)
     return A_with_row_scaling

--- a/src/iterative_ensemble_smoother/ies.py
+++ b/src/iterative_ensemble_smoother/ies.py
@@ -162,7 +162,8 @@ def exact_inversion(W, S, H, steplength):
         term = np.linalg.solve(C, S.T @ H)
     except np.linalg.LinAlgError:
         raise ValueError(
-            "Fit produces NaNs. Check your response matrix for outliers or use an inversion type with truncation."
+            "Fit produces NaNs. Check your response matrix for outliers "
+            "or use an inversion type with truncation."
         )
 
     return W - steplength * (W - term)

--- a/src/iterative_ensemble_smoother/utils.py
+++ b/src/iterative_ensemble_smoother/utils.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
-from typing import Tuple, Optional, TYPE_CHECKING
+
+from typing import TYPE_CHECKING, Optional, Tuple
 
 import numpy as np
-import scipy as sp  # type: ignore
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -18,7 +18,8 @@ def steplength_exponential(
     This is an implementation of Eq. (49), which calculates a suitable step length for
     the update step, from the book:
 
-    Geir Evensen, Formulating the history matching problem with consistent error statistics,
+    Geir Evensen, Formulating the history matching problem with
+    consistent error statistics,
     Computational Geosciences (2021) 25:945 –970
 
     Examples
@@ -82,7 +83,8 @@ def _validate_inputs(
 ) -> None:
     if response_ensemble.ndim != 2:
         raise ValueError(
-            "response_ensemble must be a matrix of size (number of responses by number of realizations)"
+            "response_ensemble must be a matrix of size "
+            "(number of responses by number of realizations)"
         )
 
     num_responses = response_ensemble.shape[0]
@@ -90,7 +92,8 @@ def _validate_inputs(
 
     if response_ensemble.shape[1] != ensemble_size:
         raise ValueError(
-            "response_ensemble and parameter_ensemble must have the same number of columns"
+            "response_ensemble and parameter_ensemble "
+            "must have the same number of columns"
         )
 
     if observation_errors.ndim == 2:
@@ -100,7 +103,8 @@ def _validate_inputs(
             )
         if observation_errors.shape[0] != len(observation_values):
             raise ValueError(
-                "observation_errors covariance matrix must match size of observation_values"
+                "observation_errors covariance matrix "
+                "must match size of observation_values"
             )
         if not np.all(np.abs(observation_errors - observation_errors.T) < 1e-8):
             raise ValueError(
@@ -108,17 +112,20 @@ def _validate_inputs(
             )
     elif len(observation_errors) != len(observation_values):
         raise ValueError(
-            "observation_errors and observation_values must have the same number of elements"
+            "observation_errors and observation_values must "
+            "have the same number of elements"
         )
 
     if len(observation_values) != num_responses:
         raise ValueError(
-            "observation_values must have the same number of elements as there are responses"
+            "observation_values must have the same number "
+            "of elements as there are responses"
         )
 
     if param_ensemble is not None and param_ensemble.ndim != 2:
         raise ValueError(
-            "parameter_ensemble must be a matrix of size (number of parameters by number of realizations)"
+            "parameter_ensemble must be a matrix of size "
+            "(number of parameters by number of realizations)"
         )
 
     if param_ensemble is not None and param_ensemble.shape[1] != ensemble_size:

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -1,7 +1,9 @@
-from iterative_ensemble_smoother import ES, SIES
+import re
+
 import numpy as np
 import pytest
-import re
+
+from iterative_ensemble_smoother import ES, SIES
 
 
 def test_that_repr_can_be_created():
@@ -26,7 +28,8 @@ def test_that_bad_inputs_cause_nice_error_messages():
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "response_ensemble must be a matrix of size (number of responses by number of realizations)"
+            "response_ensemble must be a matrix of size "
+            "(number of responses by number of realizations)"
         ),
     ):
         _ = SIES().fit(Y.ravel(), obs_errors, obs_values)
@@ -34,7 +37,8 @@ def test_that_bad_inputs_cause_nice_error_messages():
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "observation_errors and observation_values must have the same number of elements"
+            "observation_errors and observation_values "
+            "must have the same number of elements"
         ),
     ):
         _ = SIES().fit(Y, obs_errors[1:], obs_values)
@@ -42,14 +46,18 @@ def test_that_bad_inputs_cause_nice_error_messages():
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "observation_values must have the same number of elements as there are responses"
+            "observation_values must have the same number "
+            "of elements as there are responses"
         ),
     ):
         _ = SIES().fit(Y, obs_errors[1:], obs_values[1:])
 
     with pytest.raises(
         ValueError,
-        match="param_ensemble and response_ensemble must have the same number of columns",
+        match=(
+            "param_ensemble and response_ensemble must "
+            "have the same number of columns"
+        ),
     ):
         _ = SIES().fit(
             Y,
@@ -61,7 +69,8 @@ def test_that_bad_inputs_cause_nice_error_messages():
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "parameter_ensemble must be a matrix of size (number of parameters by number of realizations)"
+            "parameter_ensemble must be a matrix of size "
+            "(number of parameters by number of realizations)"
         ),
     ):
         _ = SIES().fit(
@@ -83,7 +92,10 @@ def test_that_nans_produced_due_to_outliers_in_responses_are_handled():
 
     with pytest.raises(
         ValueError,
-        match="Fit produces NaNs. Check your response matrix for outliers or use an inversion type with truncation.",
+        match=(
+            "Fit produces NaNs. Check your response matrix for "
+            "outliers or use an inversion type with truncation."
+        ),
     ):
         smoother.fit(response_ensemble, obs_error, obs_value, inversion="exact")
 
@@ -100,7 +112,5 @@ def test_that_nans_produced_due_to_outliers_in_responses_are_handled():
 
 
 if __name__ == "__main__":
-    import pytest
-
     # --durations=10  <- May be used to show potentially slow tests
     pytest.main(args=[__file__, "--doctest-modules", "-v", "-v"])

--- a/tests/test_esmda.py
+++ b/tests/test_esmda.py
@@ -180,7 +180,9 @@ class TestESMDA:
             return a * X + b
 
         # Analytical solution given by Bishop
-        inv = lambda x: 1 / x  # Matrix inversion for 1D matrix
+        def inv(x):
+            return 1 / x  # Matrix inversion for 1D matrix
+
         COV = inv(inv(S) + a * inv(C_D) * a)
         MEAN = COV * ((a * inv(C_D)) * (G(X_true) - b) + inv(S) * mu)
 
@@ -291,7 +293,7 @@ class TestESMDA:
     @pytest.mark.parametrize("S", [1, 3, 9])
     # Number of iterations
     @pytest.mark.parametrize("alpha", [5, 10, 15])
-    def test_that_single_and_multiple_assimilations_achieve_same_result_for_1D_gauss_linear_case(
+    def test_that_single_and_multiple_assimil_give_same_res_for_1D_gauss_linear_case(
         self, alpha, mu, S, X_true, C_D
     ):
         # Here we test on a Guass-linear case.

--- a/tests/test_esmda_inversion.py
+++ b/tests/test_esmda_inversion.py
@@ -6,12 +6,11 @@ from iterative_ensemble_smoother.esmda_inversion import (
     inversion_exact_lstsq,
     inversion_exact_naive,
     inversion_exact_rescaled,
+    inversion_exact_subspace_woodbury,
     inversion_rescaled_subspace,
     inversion_subspace,
-    inversion_exact_subspace_woodbury,
     normalize_alpha,
 )
-
 
 # If `truncation` is 1.0, then all of these produce the same result
 EXACT_INVERSIONS = [
@@ -111,7 +110,7 @@ class TestEsmdaInversion:
 
     @pytest.mark.parametrize("function", APPROX_INVERSIONS)
     @pytest.mark.parametrize("num_outputs", [10])
-    def test_that_approximate_inversions_do_not_compute_exact_answer_with_few_ensemble_members(
+    def test_that_approximate_inversions_do_not_compute_exact_answer_with_few_members(
         self, function, num_outputs
     ):
         """With few ensemble members, the approximate methods should not return

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,6 +1,6 @@
 import numpy as np
-import pytest
 import pandas as pd
+import pytest
 from p_tqdm import p_map
 
 import iterative_ensemble_smoother as ies
@@ -289,7 +289,8 @@ def test_that_sies_converges_to_es_in_gauss_linear_case():
     smoother_es = ies.ES(seed=seed)
     smoother_es.fit(
         response_ensemble,
-        d.sd.values,  # Assume diagonal ensemble covariance matrix for the measurement perturbations.
+        # Assume diagonal ensemble covariance matrix for the measurement perturbations.
+        d.sd.values,
         d.value.values,
     )
     params_es = smoother_es.update(X)
@@ -605,7 +606,8 @@ def test_memory_usage():
     nbytes += noise.nbytes  # Creating D
     nbytes += (
         noise.nbytes
-    )  # scaling response_ensemble (can't scale in-place because response_ensemble is an input argument)
+    )  # scaling response_ensemble (can't scale in-place because
+    # response_ensemble is an input argument)
     nbytes += 80000 # Omega in C++ (ensemble_size, ensemble_size)
     nbytes += Y.nbytes # Solving for S^T needs Y^T which causes a copy in C++ code
     nbytes += Y.nbytes # Solving for S^T causes both Y^T and S^T to be in memory

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -7,12 +7,11 @@ from numpy import testing
 from scipy.special import erf
 
 import iterative_ensemble_smoother as ies
-from iterative_ensemble_smoother.experimental import (
-    ensemble_smoother_update_step_row_scaling,
-)
-
 from iterative_ensemble_smoother._iterative_ensemble_smoother import (
     steplength_exponential,
+)
+from iterative_ensemble_smoother.experimental import (
+    ensemble_smoother_update_step_row_scaling,
 )
 
 
@@ -23,7 +22,7 @@ def fix_seed(seed=123456789):
 
 
 def guassian_to_uniform(min_x, max_x):
-    """Maps a standard guassian random variable
+    """Maps a standard gaussian random variable
         to random variable, uniformly distributied between
         min_x and max_x.
     :param min_x: The lower bound on the returned value.
@@ -44,7 +43,7 @@ def guassian_to_uniform(min_x, max_x):
 # iterative_ensemble_smoother library.
 
 # The setup contains a forward model (a second degree polynomial in this case),
-# where the coefficents of the polynomial are the model parameters.
+# where the coefficients of the polynomial are the model parameters.
 
 # There are 5 time steps t=0,1,2,3,4 and 3 observations at t=0,2,4.
 number_of_observations = 3


### PR DESCRIPTION
See issue #145 
IMP: add ruff, codespell and isort to pre-commit hooks + do required corrections to comply with the tools

Note: I haven't add mypy since it is already covered by tox. But it could be an option in a second PR.