### PR TITLE
Float32 inputs lead to float32 outputs

### DIFF
--- a/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
+++ b/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
@@ -170,9 +170,17 @@ class SIES:
             ensemble_mask = np.ones(ensemble_size, dtype=bool)
         self.ensemble_mask = ensemble_mask
 
+        use_float32_dtype = (
+            observation_errors.dtype == np.float32
+            or observation_values.dtype == np.float32
+        )
+        dtype = np.float32 if use_float32_dtype else np.float64
+
         # If it's the first time the method is called, create coeff matrix
         if not hasattr(self, "coefficient_matrix"):
-            self.coefficient_matrix = np.zeros(shape=(ensemble_size, ensemble_size))
+            self.coefficient_matrix = np.zeros(
+                shape=(ensemble_size, ensemble_size), dtype=dtype
+            )
 
         # ---------------------------------------------------------------------
         # ----------- Computations corresponding to algorithm 1 ---------------
@@ -184,6 +192,7 @@ class SIES:
             observation_values=observation_values,
             ensemble_size=ensemble_size,
         )
+        E = E.astype(dtype)
         assert E.shape == (num_obs, ensemble_size)
 
         # Transform covariance matrix to correlation matrix

--- a/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
+++ b/src/iterative_ensemble_smoother/_iterative_ensemble_smoother.py
@@ -170,11 +170,7 @@ class SIES:
             ensemble_mask = np.ones(ensemble_size, dtype=bool)
         self.ensemble_mask = ensemble_mask
 
-        use_float32_dtype = (
-            observation_errors.dtype == np.float32
-            or observation_values.dtype == np.float32
-        )
-        dtype = np.float32 if use_float32_dtype else np.float64
+        dtype = observation_values.dtype
 
         # If it's the first time the method is called, create coeff matrix
         if not hasattr(self, "coefficient_matrix"):

--- a/tests/test_esmda.py
+++ b/tests/test_esmda.py
@@ -376,8 +376,8 @@ class TestESMDAMemory:
     @pytest.mark.parametrize("diagonal", [True, False])
     def test_that_float_dtypes_are_preserved(self, inversion, dtype, diagonal):
         """If every matrix passed is of a certain dtype, then the output
-        should also be of the same dtype. Float16 does not work with linalg,
-        and float128 is probably too high-precision."""
+        should also be of the same dtype. 'linalg' does not support float16
+        nor float128."""
 
         rng = np.random.default_rng(42)
 

--- a/tests/test_esmda.py
+++ b/tests/test_esmda.py
@@ -371,6 +371,47 @@ class TestESMDAMemory:
         for _ in range(esmda.num_assimilations()):
             esmda.assimilate(X_prior, Y_prior)
 
+    @pytest.mark.parametrize("inversion", ["exact", "subspace"])
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    @pytest.mark.parametrize("diagonal", [True, False])
+    def test_that_float_dtypes_are_preserved(self, inversion, dtype, diagonal):
+        """If every matrix passed is of a certain dtype, then the output
+        should also be of the same dtype. Float16 does not work with linalg,
+        and float128 is probably too high-precision."""
+
+        rng = np.random.default_rng(42)
+
+        num_outputs = 20
+        num_inputs = 10
+        num_ensemble = 25
+
+        # Prior is N(0, 1)
+        X_prior = rng.normal(size=(num_inputs, num_ensemble))
+        Y_prior = rng.normal(size=(num_outputs, num_ensemble))
+
+        # Measurement errors
+        C_D = np.exp(rng.normal(size=num_outputs))
+        if not diagonal:
+            C_D = np.diag(C_D)
+
+        # Observations
+        observations = rng.normal(size=num_outputs, loc=1)
+
+        # Convert types
+        X_prior = X_prior.astype(dtype)
+        Y_prior = Y_prior.astype(dtype)
+        C_D = C_D.astype(dtype)
+        observations = observations.astype(dtype)
+
+        # Create ESMDA instance from an integer `alpha` and run it
+        esmda = ESMDA(C_D, observations, alpha=1, seed=1, inversion=inversion)
+
+        for _ in range(esmda.num_assimilations()):
+            X_posterior = esmda.assimilate(X_prior, Y_prior)
+
+        # Check that dtype of returned array matches input dtype
+        assert X_posterior.dtype == dtype
+
 
 if __name__ == "__main__":
     import pytest
@@ -379,6 +420,6 @@ if __name__ == "__main__":
         args=[
             __file__,
             "-v",
-            "-k test_that_diagonal_covariance_gives_same_answer_as_dense",
+            "-k test_that_float_dtypes_are_preserved",
         ]
     )

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -370,7 +370,7 @@ def test_that_update_correctly_multiples_gaussians(inversion, errors):
     # Assuming forward model is the identity
     Y = A
 
-    obs_val = 10
+    obs_val = 10.0
     observation_values = np.array([obs_val, obs_val, obs_val])
     smoother = ies.SIES(seed=42)
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -550,8 +550,8 @@ def test_that_diagonal_and_dense_covariance_return_the_same_result(inversion, se
 @pytest.mark.parametrize("diagonal", [True, False])
 def test_that_float_dtypes_are_preserved(inversion, dtype, diagonal):
     """If every matrix passed is of a certain dtype, then the output
-    should also be of the same dtype. Float16 does not work with linalg,
-    and float128 is probably too high-precision."""
+    should also be of the same dtype. 'linalg' does not support float16
+    nor float128."""
 
     rng = np.random.default_rng(42)
 


### PR DESCRIPTION
This closes #143

- For ESMDA, no change was needed
- For SIES, we had to make sure `E` and `W` had the correct dtype
- Regression tests are written for both ESMDA and SIES
- Neither Float16 nor Float128 is supported by linalg, so neither currently works.