### PR TITLE
Facilitate streaming (row-by-row update) in ESMDA

### DIFF
--- a/docs/source/Oscillator.py
+++ b/docs/source/Oscillator.py
@@ -12,6 +12,8 @@
 #     language: python
 #     name: python3
 # ---
+
+# %%
 # ruff: noqa: E402
 # %% [markdown]
 # # Estimating parameters of an anharmonic oscillator
@@ -54,7 +56,7 @@
 #
 #
 
-#%%
+# %%
 import numpy as np
 from matplotlib import pyplot as plt
 from scipy import stats
@@ -90,6 +92,7 @@ def plot_result(A, response_x_axis, title=None):
 
 # %% [markdown]
 # ## Setup
+
 
 # %%
 def generate_observations(K):
@@ -286,10 +289,9 @@ iterative_smoother(A)
 
 # %%
 smoother = ies.ESMDA(
-    # Here C_D is a covariance matrix. If a 1D array is passed,
-    # it is interpreted as the diagonal of the covariance matrix,
-    # and NOT as a vector of standard deviations
-    C_D=observation_errors**2,
+    # If a 1D array is passed, it is interpreted
+    # as the diagonal of the covariance matrix.
+    covariance=observation_errors**2,
     observations=observation_values,
     # The inflation factors used in ESMDA
     # They are scaled so that sum_i alpha_i^-1 = 1

--- a/src/iterative_ensemble_smoother/esmda.py
+++ b/src/iterative_ensemble_smoother/esmda.py
@@ -165,6 +165,7 @@ class ESMDA:
         self,
         X: npt.NDArray[np.double],
         Y: npt.NDArray[np.double],
+        *,
         ensemble_mask: Optional[npt.NDArray[np.bool_]] = None,
         overwrite: bool = False,
         truncation: float = 1.0,
@@ -256,6 +257,50 @@ class ESMDA:
 
         self.iteration += 1
         return X
+
+    def get_K(
+        self,
+        Y: npt.NDArray[np.double],
+        *,
+        alpha: float,
+        truncation: float = 1.0,
+    ) -> npt.NDArray[np.double]:
+        """Return a matrix K such that X_posterior = X_prior + center(X_prior) @ K.
+
+        The purpose of this method is to facilitate row-by-row, or batch-by-batch,
+        updates of X. This is useful if X is too large to fit in memory.
+
+
+        Parameters
+        ----------
+        Y : npt.NDArray[np.double]
+            DESCRIPTION.
+        * : TYPE
+            DESCRIPTION.
+        alpha : float
+            DESCRIPTION.
+        truncation : float, optional
+            DESCRIPTION. The default is 1.0.
+         : TYPE
+            DESCRIPTION.
+
+        Returns
+        -------
+        None.
+
+        """
+
+        D = self.get_D(size=Y.shape, alpha=alpha)
+        inversion_func = self._inversion_methods[self.inversion]
+        return inversion_func(
+            alpha=alpha,
+            C_D=self.C_D,
+            D=D,
+            Y=Y,
+            X=None,
+            truncation=truncation,
+            return_K=True,  # Ensures that we don't need X
+        )
 
     def get_D(self, *, size: Tuple[int, int], alpha: float) -> npt.NDArray[np.double]:
         """Create a matrix D with perturbed observations.

--- a/src/iterative_ensemble_smoother/esmda_inversion.py
+++ b/src/iterative_ensemble_smoother/esmda_inversion.py
@@ -435,9 +435,6 @@ def inversion_subspace(
            [0., 0., 0.]])
 
     """
-    print(
-        {"alpha": alpha, "C_D": C_D, "D": D, "Y": Y, "X": X, "truncation": truncation}
-    )
 
     # N_n is the number of observations
     # N_e is the number of members in the ensemble

--- a/tests/test_esmda.py
+++ b/tests/test_esmda.py
@@ -422,12 +422,8 @@ def test_row_by_row_assimilation(inversion):
     for alpha_i in smoother.alpha:
         K = smoother.compute_transition_matrix(Y=g(X), alpha=alpha_i)
 
-        # TODO: Why is this equivalent? ...
-        X_centered = X - np.mean(X, axis=1, keepdims=True)
-        assert np.allclose(X_centered @ K, X @ K)
-
         # Here we could loop over each row in X and multiply by K
-        X += X_centered @ K
+        X += X @ K
 
     X_posterior_lowlevel_API = np.copy(X)
 

--- a/tests/test_esmda.py
+++ b/tests/test_esmda.py
@@ -420,7 +420,7 @@ def test_row_by_row_assimilation(inversion):
     )
     X = np.copy(X_prior)
     for alpha_i in smoother.alpha:
-        K = smoother.get_K(Y=g(X), alpha=alpha_i)
+        K = smoother.compute_transition_matrix(Y=g(X), alpha=alpha_i)
 
         # TODO: Why is this equivalent? ...
         X_centered = X - np.mean(X, axis=1, keepdims=True)

--- a/tests/test_esmda.py
+++ b/tests/test_esmda.py
@@ -43,18 +43,24 @@ class TestESMDA:
         Y_prior = rng.normal(size=(num_outputs, num_ensemble))
 
         # Measurement errors
-        C_D = np.exp(rng.normal(size=num_outputs))
+        covariance = np.exp(rng.normal(size=num_outputs))
 
         # Observations
         observations = rng.normal(size=num_outputs, loc=1)
 
-        esmda = ESMDA(C_D, observations, alpha=alpha, seed=seed, inversion=inversion)
+        esmda = ESMDA(
+            covariance, observations, alpha=alpha, seed=seed, inversion=inversion
+        )
         X_posterior1 = np.copy(X_prior)
         for _ in range(esmda.num_assimilations()):
             X_posterior1 = esmda.assimilate(X_posterior1, Y_prior)
 
         esmda = ESMDA(
-            np.diag(C_D), observations, alpha=alpha, seed=seed, inversion=inversion
+            np.diag(covariance),
+            observations,
+            alpha=alpha,
+            seed=seed,
+            inversion=inversion,
         )
         X_posterior2 = np.copy(X_prior)
         for _ in range(esmda.num_assimilations()):
@@ -88,18 +94,18 @@ class TestESMDA:
         X_prior = rng.normal(size=(num_inputs, num_ensemble))
 
         # Measurement errors
-        C_D = np.eye(num_outputs)
+        covariance = np.eye(num_outputs)
 
         # The true inputs and observations, a result of running with X_true = 1
         X_true = np.ones(shape=(num_inputs,))
         observations = G(X_true)
 
         # Prepare ESMDA instance running with lower number of ensemble members
-        esmda_subset = ESMDA(C_D, observations, alpha=alpha, seed=seed)
+        esmda_subset = ESMDA(covariance, observations, alpha=alpha, seed=seed)
         X_i_subset = np.copy(X_prior[:, ensemble_mask])
 
         # Prepare ESMDA instance running with all ensemble members
-        esmda_masked = ESMDA(C_D, observations, alpha=alpha, seed=seed)
+        esmda_masked = ESMDA(covariance, observations, alpha=alpha, seed=seed)
         X_i = np.copy(X_prior)
 
         # Run both
@@ -133,20 +139,20 @@ class TestESMDA:
         X_prior = rng.normal(size=(num_inputs, num_ensemble))
 
         # Measurement errors
-        C_D = np.eye(num_outputs)
+        covariance = np.eye(num_outputs)
 
         # The true inputs and observations, a result of running with N(1, 1)
         X_true = rng.normal(size=(num_inputs,)) + 1
         observations = G(X_true)
 
         # Create ESMDA instance from an integer `alpha` and run it
-        esmda_integer = ESMDA(C_D, observations, alpha=5, seed=seed)
+        esmda_integer = ESMDA(covariance, observations, alpha=5, seed=seed)
         X_i_int = np.copy(X_prior)
         for _ in range(esmda_integer.num_assimilations()):
             X_i_int = esmda_integer.assimilate(X_i_int, G(X_i_int))
 
         # Create another ESMDA instance from a vector `alpha` and run it
-        esmda_array = ESMDA(C_D, observations, alpha=np.ones(5), seed=seed)
+        esmda_array = ESMDA(covariance, observations, alpha=np.ones(5), seed=seed)
         X_i_array = np.copy(X_prior)
         for _ in range(esmda_array.num_assimilations()):
             X_i_array = esmda_array.assimilate(X_i_array, G(X_i_array))
@@ -355,21 +361,21 @@ class TestESMDAMemory:
         Y_prior = rng.normal(size=(num_outputs, num_ensemble))
 
         # Measurement errors
-        C_D = np.exp(rng.normal(size=num_outputs))
+        covariance = np.exp(rng.normal(size=num_outputs))
 
         # Observations
         observations = rng.normal(size=num_outputs, loc=1)
 
-        return X_prior, Y_prior, C_D, observations
+        return X_prior, Y_prior, covariance, observations
 
     @pytest.mark.limit_memory("138 MB")
     def test_ESMDA_memory_usage_subspace_inversion(self, setup):
         # TODO: Currently this is a regression test. Work to improve memory usage.
 
-        X_prior, Y_prior, C_D, observations = setup
+        X_prior, Y_prior, covariance, observations = setup
 
         # Create ESMDA instance from an integer `alpha` and run it
-        esmda = ESMDA(C_D, observations, alpha=1, seed=1, inversion="subspace")
+        esmda = ESMDA(covariance, observations, alpha=1, seed=1, inversion="subspace")
 
         for _ in range(esmda.num_assimilations()):
             esmda.assimilate(X_prior, Y_prior)
@@ -393,9 +399,9 @@ class TestESMDAMemory:
         Y_prior = rng.normal(size=(num_outputs, num_ensemble))
 
         # Measurement errors
-        C_D = np.exp(rng.normal(size=num_outputs))
+        covariance = np.exp(rng.normal(size=num_outputs))
         if not diagonal:
-            C_D = np.diag(C_D)
+            covariance = np.diag(covariance)
 
         # Observations
         observations = rng.normal(size=num_outputs, loc=1)
@@ -403,11 +409,11 @@ class TestESMDAMemory:
         # Convert types
         X_prior = X_prior.astype(dtype)
         Y_prior = Y_prior.astype(dtype)
-        C_D = C_D.astype(dtype)
+        covariance = covariance.astype(dtype)
         observations = observations.astype(dtype)
 
         # Create ESMDA instance from an integer `alpha` and run it
-        esmda = ESMDA(C_D, observations, alpha=1, seed=1, inversion=inversion)
+        esmda = ESMDA(covariance, observations, alpha=1, seed=1, inversion=inversion)
 
         for _ in range(esmda.num_assimilations()):
             X_posterior = esmda.assimilate(X_prior, Y_prior)

--- a/tests/test_esmda.py
+++ b/tests/test_esmda.py
@@ -405,15 +405,12 @@ def test_row_by_row_assimilation(inversion):
         seed=1,
     )
     X = np.copy(X_prior)
-    print(X_prior)
     for iteration in range(smoother.num_assimilations()):
         X = smoother.assimilate(X, g(X))
-        print(X)
 
     X_posterior_highlevel_API = np.copy(X)
 
     # =========== Use the low-level level API ===========
-    print("# =========== Use the low-level level API ===========")
     smoother = ESMDA(
         covariance=covariance,
         observations=observations,
@@ -422,16 +419,15 @@ def test_row_by_row_assimilation(inversion):
         seed=1,
     )
     X = np.copy(X_prior)
-    print(X_prior)
     for alpha_i in smoother.alpha:
         K = smoother.get_K(Y=g(X), alpha=alpha_i)
 
-        # TODO: Why is this equivalent?
+        # TODO: Why is this equivalent? ...
         X_centered = X - np.mean(X, axis=1, keepdims=True)
         assert np.allclose(X_centered @ K, X @ K)
 
+        # Here we could loop over each row in X and multiply by K
         X += X_centered @ K
-        print(X)
 
     X_posterior_lowlevel_API = np.copy(X)
 

--- a/tests/test_esmda_inversion.py
+++ b/tests/test_esmda_inversion.py
@@ -68,8 +68,8 @@ class TestEsmdaInversion:
         ans = function(alpha=alpha, C_D=C_D, D=D, Y=Y, X=X)
         K = function(alpha=alpha, C_D=C_D, D=D, Y=Y, X=None, return_K=True)
 
-        X_centered = X - np.mean(X, axis=1, keepdims=True)
-        assert np.allclose(X + ans, X + X_centered @ K)
+        X - np.mean(X, axis=1, keepdims=True)
+        assert np.allclose(X + ans, X + X @ K)
 
     @pytest.mark.parametrize("length", list(range(1, 101, 5)))
     def test_that_the_sum_of_normalize_alpha_is_one(self, length):

--- a/tests/test_esmda_inversion.py
+++ b/tests/test_esmda_inversion.py
@@ -37,6 +37,40 @@ TRUNCATION_INVERSIONS = [
 
 
 class TestEsmdaInversion:
+    # Functions that take the parameter return_K
+    @pytest.mark.parametrize(
+        "function",
+        [inversion_exact_cholesky, inversion_subspace],
+    )
+    @pytest.mark.parametrize("ensemble_members", [5, 10, 15])
+    @pytest.mark.parametrize("num_outputs", [5, 10, 15])
+    @pytest.mark.parametrize("num_inputs", [5, 10, 15])
+    def test_that_returning_K_is_equivalent_to_full_computation(
+        self, function, ensemble_members, num_outputs, num_inputs
+    ):
+        # ensemble_members, num_outputs, num_inputs = 5, 10, 15
+
+        np.random.seed(ensemble_members * 100 + num_outputs * 10 + num_inputs)
+
+        # Create positive symmetric definite covariance C_D
+        E = np.random.randn(num_outputs, num_outputs)
+        C_D = E.T @ E
+
+        # Set alpha to something other than 1 to test that it works
+        alpha = 3
+
+        # Create observations
+        D = np.random.randn(num_outputs, ensemble_members)
+        Y = np.random.randn(num_outputs, ensemble_members)
+        X = np.random.randn(num_inputs, ensemble_members)
+
+        # Test both with and without X / return_K
+        ans = function(alpha=alpha, C_D=C_D, D=D, Y=Y, X=X)
+        K = function(alpha=alpha, C_D=C_D, D=D, Y=Y, X=None, return_K=True)
+
+        X_centered = X - np.mean(X, axis=1, keepdims=True)
+        assert np.allclose(X + ans, X + X_centered @ K)
+
     @pytest.mark.parametrize("length", list(range(1, 101, 5)))
     def test_that_the_sum_of_normalize_alpha_is_one(self, length):
         # Generate random array
@@ -350,6 +384,6 @@ if __name__ == "__main__":
         args=[
             __file__,
             "-v",
-            "-k test_that_exact_inverions_are_equal_with_few_ensemble_members",
+            "-k test_that_returning_K_is_equivalent_to_full_computation",
         ]
     )

--- a/tests/test_esmda_inversion.py
+++ b/tests/test_esmda_inversion.py
@@ -68,7 +68,6 @@ class TestEsmdaInversion:
         ans = function(alpha=alpha, C_D=C_D, D=D, Y=Y, X=X)
         K = function(alpha=alpha, C_D=C_D, D=D, Y=Y, X=None, return_K=True)
 
-        X - np.mean(X, axis=1, keepdims=True)
         assert np.allclose(X + ans, X + X @ K)
 
     @pytest.mark.parametrize("length", list(range(1, 101, 5)))


### PR DESCRIPTION
To support row-by-row (parameter by parameter) computation, either literally by updating a single parameter or updating batches, we should avoid doing duplicate work.
Consider the equation:

$$C_{MD}  (C_{DD} + \alpha C_D)^{-1}  (D - Y)=X Y^T /(N-1)  (C_{DD} + \alpha C_D)^{-1}  (D - Y)$$

If we update row by row and introduce a transition matrix $K := Y^T /(N-1)  (C_{DD} + \alpha C_D)^{-1}  (D - Y) $,
then $[x_1 | x_2 | \ldots]^T K = [x_1 K | x_2 K | \ldots ]^T$. In other words, we can pre-compute $K$, since it's independent on $X$, and apply it row-by-row or group-by-group, instead of re-computing it for each group.

----------------------------

This PR proposes two methods for this:
- `compute_transition_matrix`, which computes the transition matrix $K$
- `perturb_observations`, called by both `compute_transition_matrix` and `assimilate`, to avoid duplicating code

Note: this PR assumes #161 will be merged.


-----------------------------

**I also realized that we don't have to center both $X$ and $Y$!** So I changed the code away from that, saving both memory and time by only centering the smaller matrix $Y$. See [this comment](https://github.com/equinor/iterative_ensemble_smoother/issues/160#issuecomment-1770981302). This is also documented in the code with a few lines.