### PR TITLE
Added LITERATURE.md

### DIFF
--- a/LITERATURE.md
+++ b/LITERATURE.md
@@ -1,0 +1,30 @@
+# Literature
+
+A list of literature that we find useful for Data Assimilation.
+Could be moved to `docs/source` eventually.
+
+## Papers
+
+### SIES
+
+- (2019) [Efficient Implementation of an Iterative Ensemble Smoother for Data Assimilation and Reservoir History Matching](https://www.frontiersin.org/articles/10.3389/fams.2019.00047/full) by Evensen et al
+
+### ESMDA
+
+- (2012) [History matching time-lapse seismic data using the ensemble Kalman filter with multiple data assimilations](https://link.springer.com/article/10.1007/s10596-012-9275-5) by Emerick et al
+- (2013) [Ensemble smoother with multiple data assimilation](https://www.sciencedirect.com/science/article/abs/pii/S0098300412000994) by Emerick et al
+
+### Covariance regularization
+
+- (2022) [GraphSPME: Markov Precision Matrix Estimation and Asymptotic Stein-Type Shrinkage](https://arxiv.org/abs/2205.07584) by Lunde et al
+
+## Books
+
+### Preliminaries
+
+- (2006) [Pattern Recognition and Machine Learning](https://www.amazon.com/Pattern-Recognition-Learning-Information-Statistics/dp/0387310738) by Bishop
+
+### Data Assimilation
+
+- (2014) [Data Assimilation: The Ensemble Kalman Filter](https://www.amazon.com/Data-Assimilation-Ensemble-Kalman-Filter/dp/3642424767/) by Evensen
+- (2022) [Data Assimilation Fundamentals: A Unified Formulation of the State and Parameter Estimation Problem](https://www.amazon.com/Data-Assimilation-Fundamentals-Formulation-Environment/dp/3030967085/) by Evensen


### PR DESCRIPTION
- I thought maintaining a `LITERATURE.md` Markdown might be easier than adding it to sphinx.
- Also, the sphinx docs should arguably only documen what we have actually implemented, but I want this documentation list to be more general, having e.g. preliminary readings, things we are interesting in, but have not implemented, etc.

After merging others can add their sources too. I don't want to add everything for everyone, since I don't have the full overview.