### PR TITLE
Relax assertion on correlation matrix

### DIFF
--- a/src/iterative_ensemble_smoother/experimental.py
+++ b/src/iterative_ensemble_smoother/experimental.py
@@ -149,9 +149,14 @@ class AdaptiveESMDA(BaseESMDA):
         # Compute the correlation matrix from the covariance matrix
         corr_XY = (cov_XY / stds_X[:, np.newaxis]) / stds_Y[np.newaxis, :]
 
-        # Perform checks
-        assert corr_XY.max() <= 1
-        assert corr_XY.min() >= -1
+        # Perform checks. There appears to be occasional numerical issues in
+        # the equation. With 2 ensemble members, we get e.g. a max value of
+        # 1.0000000000016778. We allow some leeway and clip the results.
+        eps = 1e-8
+        assert corr_XY.max() <= 1 + eps
+        assert corr_XY.min() >= -1 - eps
+
+        corr_XY = np.clip(corr_XY, a_min=-1, a_max=1)
         return corr_XY
 
     def assimilate(self, X, Y, D, alpha, correlation_threshold=None, verbose=False):

--- a/src/iterative_ensemble_smoother/experimental.py
+++ b/src/iterative_ensemble_smoother/experimental.py
@@ -3,6 +3,7 @@ Contains (publicly available, but not officially supported) experimental
 features of iterative_ensemble_smoother
 """
 import numbers
+import warnings
 from typing import List, Optional, Tuple, Union
 
 import numpy as np
@@ -153,8 +154,10 @@ class AdaptiveESMDA(BaseESMDA):
         # the equation. With 2 ensemble members, we get e.g. a max value of
         # 1.0000000000016778. We allow some leeway and clip the results.
         eps = 1e-8
-        assert corr_XY.max() <= 1 + eps
-        assert corr_XY.min() >= -1 - eps
+        if not ((corr_XY.max() <= 1 + eps) and (corr_XY.min() >= -1 - eps)):
+            msg = "Cross-correlation matrix has entries not in [-1, 1]."
+            msg += f"The min and max values are: {corr_XY.min()} and {corr_XY.max()}"
+            warnings.warn(msg)
 
         corr_XY = np.clip(corr_XY, a_min=-1, a_max=1)
         return corr_XY


### PR DESCRIPTION
The assert is too restrictive. With very few ensemble members (2) I get numerical issues. The assert is too strict, and does not allow for this. Still, if something goes "very" wrong I want to emit a warning.