### PR TITLE
Profiling AdaptiveESMDA

### DIFF
--- a/docs/source/Adaptive.py
+++ b/docs/source/Adaptive.py
@@ -1,0 +1,378 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: ipynb,py:percent
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.15.2
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# %%
+# ruff: noqa: E402
+
+# %% [markdown]
+# # Adaptive Localization
+#
+# In this example we run adaptive localization
+# on a linear sparse problem.
+#
+# - Each response is only affected by $3$ parameters.
+# - This is represented by a tridiagonal matrix $A$ in the forward model $g(x) = Ax$.
+# - The problem is Gauss-Linear, so in this case ESMDA will sample
+#   the true posterior when the number of ensemble members (realizations) is large.
+
+# %% [markdown]
+# ## Import packages
+
+# %%
+import numpy as np
+import scipy as sp
+from matplotlib import pyplot as plt
+
+from iterative_ensemble_smoother import ESMDA
+from iterative_ensemble_smoother.experimental import AdaptiveESMDA
+
+# %% [markdown]
+# ## Create problem data
+#
+# Some settings worth experimenting with:
+#
+# - Decreasing `prior_std=1` will pull the posterior solution toward zero.
+# - Increasing `num_ensemble` will increase the quality of the solution.
+# - Increasing `num_observations / num_parameters`
+#   will increase the quality of the solution.
+
+# %%
+rng = np.random.default_rng(42)
+
+# Dimensionality of the problem
+num_parameters = 10_000
+num_observations = 1000
+num_ensemble = 25
+prior_std = 1
+
+# Number of iterations to use in ESMDA
+alpha = 5
+
+# %% [markdown]
+# ## Create problem data - sparse tridiagonal matrix $A$
+
+# %%
+diagonal = np.ones(min(num_parameters, num_observations))
+
+# Create a tridiagonal matrix (easiest with scipy)
+A = sp.sparse.diags(
+    [diagonal, diagonal, diagonal],
+    offsets=[-1, 0, 1],
+    shape=(num_observations, num_parameters),
+    dtype=float,
+).toarray()
+
+# We add some noise that is insignificant compared to the
+# actual local structure in the forward model
+A = A + rng.standard_normal(size=A.shape) * 0.01
+
+plt.title("Linear mapping $A$ in forward model $g(x) = Ax$")
+plt.imshow(A)
+plt.xlabel("Parameters (inputs)")
+plt.ylabel("Responses (outputs)")
+plt.tight_layout()
+plt.show()
+
+
+# %%
+def g(X):
+    """Apply the forward model."""
+    return A @ X
+
+
+# Create observations: obs = g(x) + N(0, 1)
+x_true = np.linspace(-1, 1, num=num_parameters)
+observation_noise = rng.standard_normal(size=num_observations)  # N(0, 1) noise
+observations = g(x_true) + observation_noise
+
+# Initial ensemble X ~ N(0, prior_std) and diagonal covariance with ones
+X = rng.normal(size=(num_parameters, num_ensemble)) * prior_std
+
+# Covariance matches the noise added to observations above
+covariance = np.ones(num_observations)  # N(0, 1) covariance
+
+# %% [markdown]
+# ## Solve the maximum likelihood problem
+#
+# We can solve $Ax = b$, where $b$ is the observations,
+# for the maximum likelihood estimate.
+#
+# Notice that unlike using a Ridge model,
+# solving $Ax = b$ directly does not use any prior information.
+
+# %%
+x_ml, *_ = np.linalg.lstsq(A, observations, rcond=None)
+
+plt.figure(figsize=(8, 3))
+plt.scatter(np.arange(len(x_true)), x_true, label="True parameter values")
+plt.scatter(np.arange(len(x_true)), x_ml, label="ML estimate (no prior)")
+plt.xlabel("Parameter index")
+plt.ylabel("Parameter value")
+plt.grid(True, ls="--", zorder=0, alpha=0.33)
+plt.legend()
+plt.show()
+
+# %% [markdown]
+# ## Solve using ESMDA
+#
+# We crease an `ESMDA` instance and solve the Guass-linear problem.
+
+# %%
+# %%time
+
+
+smoother = ESMDA(
+    covariance=covariance,
+    observations=observations,
+    alpha=alpha,
+    seed=1,
+)
+
+X_i = np.copy(X)
+for i, alpha_i in enumerate(smoother.alpha, 1):
+    print(
+        f"ESMDA iteration {i}/{smoother.num_assimilations()}"
+        + f" with inflation factor alpha_i={alpha_i}"
+    )
+    X_i = smoother.assimilate(X_i, Y=g(X_i))
+
+
+X_posterior = np.copy(X_i)
+
+# %% [markdown]
+# ## Plot and compare solutions
+#
+# Compare the true parameters with both the ML estimate
+# from linear regression and the posterior means obtained using `ESMDA`.
+
+# %%
+plt.figure(figsize=(8, 3))
+plt.scatter(np.arange(len(x_true)), x_true, label="True parameter values")
+plt.scatter(np.arange(len(x_true)), x_ml, label="ML estimate (no prior)")
+plt.scatter(
+    np.arange(len(x_true)), np.mean(X_posterior, axis=1), label="Posterior mean"
+)
+plt.xlabel("Parameter index")
+plt.ylabel("Parameter value")
+plt.grid(True, ls="--", zorder=0, alpha=0.33)
+plt.legend()
+plt.show()
+
+# %% [markdown]
+# ## Solve using AdaptiveESMDA
+#
+# We crease an `AdaptiveESMDA` instance and solve the Guass-linear problem.
+
+# %%
+# %%time
+
+adaptive_smoother = AdaptiveESMDA(
+    covariance=covariance,
+    observations=observations,
+    seed=1,
+)
+
+X_i = np.copy(X)
+
+# Loop over alpha defined in ESMDA instance,
+# the vector of inflation values alpha is then
+# of the same size in AdaptiveESMDA and ESMDA,
+# and it's correctly scaled
+assert np.isclose(np.sum(1 / smoother.alpha), 1), "Incorrect scaling"
+for i, alpha_i in enumerate(smoother.alpha, 1):
+    print(
+        f"AdaptiveESMDA iteration {i}/{len(smoother.alpha)}"
+        + f" with inflation factor alpha_i={alpha_i}"
+    )
+
+    # Run forward model
+    Y_i = g(X_i)
+
+    # Perturb observations
+    D_i = adaptive_smoother.perturb_observations(
+        ensemble_size=X_i.shape[1], alpha=alpha_i
+    )
+
+    # Assimilate data
+    X_i = adaptive_smoother.assimilate(X_i, Y=Y_i, D=D_i, alpha=alpha_i, verbose=False)
+
+
+X_adaptive_posterior = np.copy(X_i)
+
+# %%
+
+# %%
+# %load_ext line_profiler
+
+# %%
+# %lprun -f AdaptiveESMDA.compute_cross_covariance_multiplier
+# adaptive_smoother.assimilate(X_i, Y=Y_i, D=D_i, alpha=alpha_i, verbose=False)
+
+# %%
+1 / 0
+
+# %%
+a = np.ones(3333)
+X = np.random.randn(3333, 3333)
+
+# %%
+# %timeit np.fill_diagonal(X, X.diagonal() + a)
+
+# %%
+# %timeit X.flat[::X.shape[0] + 1] += a
+
+# %%
+a = rng.integers(0, 100, 10**6)
+
+# %%
+# %timeit np.unique(a)
+
+# %%
+a = rng.integers(0, 100, 10**8)
+
+# %%
+# %timeit np.unique(a)
+
+# %%
+4.3 / 0.032
+
+# %%
+0.032 / (300 * 1e-6)
+
+# %%
+plt.figure(figsize=(8, 3))
+plt.scatter(np.arange(len(x_true)), x_true, label="True parameter values")
+plt.scatter(np.arange(len(x_true)), x_ml, label="ML estimate (no prior)")
+plt.scatter(
+    np.arange(len(x_true)), np.mean(X_posterior, axis=1), label="Posterior mean"
+)
+plt.scatter(
+    np.arange(len(x_true)),
+    np.mean(X_adaptive_posterior, axis=1),
+    label="Posterior mean (adaptive)",
+)
+plt.xlabel("Parameter index")
+plt.ylabel("Parameter value")
+plt.grid(True, ls="--", zorder=0, alpha=0.33)
+plt.legend()
+plt.show()
+
+# %% [markdown]
+# ## Correlations between true parameters and solution means
+#
+# - A more sophisticated way to measure goodness would be to use [Kullback–Leibler divergence](https://en.wikipedia.org/wiki/Kullback%E2%80%93Leibler_divergence).
+# - Here we simply look at the correlations of the means.
+
+# %%
+for arr, label in zip(
+    [
+        np.mean(X, axis=1),
+        x_ml,
+        np.mean(X_posterior, axis=1),
+        np.mean(X_adaptive_posterior, axis=1),
+    ],
+    ["Prior", "ML estimate", "Posterior mean", "Posterior mean (adaptive)"],
+):
+    corr = sp.stats.pearsonr(x_true, arr).statistic
+    print(label, corr)
+
+# %% [markdown]
+# ## Run on several ensemble sizes and seeds
+
+# %%
+ENSEMBLE_SIZES = list(range(2, 51))
+NUM_SEEDS = 10
+
+# Store average correlation coefficients
+ESMDA_corrs = []
+AdaptiveESMDA_corrs = []
+
+# Loop over increasingly large ensemble sizes
+for ensemble_size in ENSEMBLE_SIZES:
+    # Posteriors means for this size
+    ESMDA_means = []
+    AdaptiveESMDA_means = []
+
+    # Loop over seeds used in ESMDA/AdaptiveESMDA,
+    # which determine the perturbations of the observations.
+    for seed in range(NUM_SEEDS):
+        # Prior
+        X = rng.normal(size=(num_parameters, ensemble_size)) * prior_std
+
+        # ================ ESMDA ==============
+        smoother = ESMDA(
+            covariance=covariance,
+            observations=observations,
+            alpha=5,
+            seed=None,
+        )
+
+        X_i = np.copy(X)
+        for i, alpha_i in enumerate(smoother.alpha, 1):
+            X_i = smoother.assimilate(X_i, Y=g(X_i))
+
+        ESMDA_means.append(np.mean(X_i, axis=1))
+
+        # ============ AdaptiveESMDA ============
+        adaptive_smoother = AdaptiveESMDA(
+            covariance=covariance,
+            observations=observations,
+            seed=None,
+        )
+
+        X_i = np.copy(X)
+
+        for i, alpha_i in enumerate(smoother.alpha, 1):
+            # Perturb observations
+            D_i = adaptive_smoother.perturb_observations(
+                ensemble_size=X_i.shape[1], alpha=alpha_i
+            )
+
+            # Assimilate data
+            X_i = adaptive_smoother.assimilate(X_i, Y=g(X_i), D=D_i, alpha=alpha_i)
+
+        AdaptiveESMDA_means.append(np.mean(X_i, axis=1))
+
+    # Collect results for all runs of this size
+    ESMDA_corr = np.mean(
+        [sp.stats.pearsonr(x_true, arr).statistic for arr in ESMDA_means]
+    )
+    AdaptiveESMDA_corr = np.mean(
+        [sp.stats.pearsonr(x_true, arr).statistic for arr in AdaptiveESMDA_means]
+    )
+
+    ESMDA_corrs.append(ESMDA_corr)
+    AdaptiveESMDA_corrs.append(AdaptiveESMDA_corr)
+
+# %%
+# Compute correlations
+title = "ESMDA vs AdaptiveESMDA on different ensemble sizes\n"
+title += f"each point represents the average of {NUM_SEEDS} \n"
+title += "runs with different seeds (perturbations of D)\n"
+title += f"Parameters = {num_parameters}, Observations ="
+title += f" {num_observations}, len(alpha) = {len(smoother.alpha)}"
+
+
+plt.title(title)
+
+plt.plot(ENSEMBLE_SIZES, ESMDA_corrs, label="ESMDA")
+plt.plot(ENSEMBLE_SIZES, AdaptiveESMDA_corrs, label="AdaptiveESMDA")
+
+plt.xlabel("Ensemble size")
+plt.ylabel("Correlation coeff of \nposterior mean vs. true parameter vector")
+
+plt.grid(True)
+plt.legend()
+plt.show()

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -182,8 +182,9 @@ class TestAdaptiveESMDA:
     @pytest.mark.parametrize(
         "cutoffs", [(0, 1e-3), (0.1, 0.2), (0.5, 0.5 + 1e-12), (0.9, 1), (1 - 1e-3, 1)]
     )
+    @pytest.mark.parametrize("full_covariance", [True, False])
     def test_that_posterior_generalized_variance_increases_in_cutoff(
-        self, linear_problem, cutoffs
+        self, linear_problem, cutoffs, full_covariance
     ):
         """This property only holds in the limit as the number of
         ensemble members goes to infinity. As the number of ensemble
@@ -191,6 +192,8 @@ class TestAdaptiveESMDA:
 
         # Create a problem with g(x) = A @ x
         X, g, observations, covariance, rng = linear_problem
+        if full_covariance:
+            covariance = np.diag(covariance)
 
         # =============================================================================
         # SETUP ESMDA FOR LOCALIZATION AND SOLVE PROBLEM


### PR DESCRIPTION
Closes #192


## AdaptiveESMDA is slower in general

Some rough measurements first. On the sparse Gauss-Linear problem with size
```python
num_parameters = 10_000
num_observations = 1000
num_ensemble = 25
```
ESMDA takes `234 ms` while AdaptiveESMDA takes `4.13 s`.

Going up to
```python
num_parameters = 25_000
```
ESMDA takes `308 ms` while AdaptiveESMDA takes `9.7 s`.

Going up to
```python
num_parameters = 50_000
```
ESMDA takes `539 ms` while AdaptiveESMDA takes `19 s`.


-----------------------------

## Profiling `AdaptiveESMDA.assimilate`

Here is the report from 
```
%lprun -f AdaptiveESMDA.assimilate adaptive_smoother.assimilate(X_i, Y=Y_i, D=D_i, alpha=alpha_i, verbose=False)
```
the sparse Gauss-Linear problem with size
```python
num_parameters = 10_000
num_observations = 1000
num_ensemble = 25
```
Only the important parts are pasted here:

```
Timer unit: 1e-09 s

Total time: 0.795092 s
File: iterative_ensemble_smoother/src/iterative_ensemble_smoother/experimental.py
Function: assimilate at line 210

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   210                                               def assimilate(self, X, Y, D, alpha, correlation_threshold=None, verbose=False):
   211                                                   """Assimilate data and return an 
   287         1   66322453.0    7e+07      8.3          cov_XY = empirical_cross_covariance(X, Y)
   288         1       1266.0   1266.0      0.0          assert cov_XY.shape == (X.shape[0], Y.shape[0])
   289         1   82010253.0    8e+07     10.3          corr_XY = self._correlation_matrix(cov_XY, X, Y)
   290         1       4196.0   4196.0      0.0          assert corr_XY.shape == cov_XY.shape
   291                                           
   292                                                   # Determine which elements in the cross covariance matrix that will
   293                                                   # be set to zero
   294         1      26608.0  26608.0      0.0          threshold = correlation_threshold(ensemble_size=X.shape[1])
   295         1   17874591.0    2e+07      2.2          significant_corr_XY = np.abs(corr_XY) > threshold
   296                                           
   297                                                   # Pre-compute the covariance cov(Y, Y) here, and index on it later
   298         1    6570085.0    7e+06      0.8          cov_YY = empirical_cross_covariance(Y, Y)
   302      2166  414649781.0 191435.7     52.2          for (unique_row, indices_of_row) in groupby_indices(significant_corr_XY):
   303                                           
   332                                                       # Compute transition matrix T
   333      4328   99213275.0  22923.6     12.5              T = self.compute_cross_covariance_multiplier(
   338      2164     247438.0    114.3      0.0                  cov_YY=cov_YY_subset,  # Passing cov(Y, Y) avoids re-computation
   339                                                       )
   340      2164   14599430.0   6746.5      1.8              X_out[indices_of_row, :] = X_subset + cov_XY_subset @ T
```

- Computing `cov_XY` and `corr_XY` is expensive, since it takes a product of two large matrices. This is not done explicitly in ESMDA because of the order of matrix multiplication.
- `groupby_indices` is also costly.
- `compute_cross_covariance_multiplier` takes some time too.

-----------------------------

## Examining `groupby_indices`

My implementation of `groupby_indices` was based on [Fedas implementation](https://github.com/equinor/ert/blob/399d966e35f20c071b0cf82987ed423fa459bb66/src/ert/analysis/_es_update.py#L588).
I never actually compared the speed, so let's do that.

```python
def groupby_indices_feda(X):
    """Minimal implementation of groupby_indices."""
    param_correlation_sets = np.unique(X, axis=0)
    row_with_all_false = np.all(~param_correlation_sets, axis=1)
    param_correlation_sets = param_correlation_sets[~row_with_all_false]

    for param_correlation_set in param_correlation_sets:
        matching_rows = np.all(X == param_correlation_set, axis=1)
        row_indices = np.where(matching_rows)[0]
        yield (param_correlation_set, row_indices)
```

The new implementation seems to always be faster. How much faster it is depends on the structure of the matrix. The more parameter groups, the larger the difference in speed.

```
X = np.repeat((np.random.randn(50, 500) > 0.5), 50, axis=0)

X.shape # (2500, 500)

%timeit list(groupby_indices_feda(X))
110 ms ± 216 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

%timeit list(groupby_indices(X))
46.4 ms ± 216 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

X = np.repeat((np.random.randn(200, 500) > 0.5), 200, axis=0)

%timeit list(groupby_indices_feda(X))
3.56 s ± 25.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%timeit list(groupby_indices(X))
807 ms ± 8.73 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

X = np.random.randn(100 * 100, 500) > 0.5

%timeit list(groupby_indices_feda(X))
8.01 s ± 494 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%timeit list(groupby_indices(X))
113 ms ± 2.39 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

It seems like the current implemenation is faster than the initial one. It also seems unlikely that this can be sped up, since it's more or less linear.