### PR TITLE
Fix bug when using full covariance matrix in AdaptiveESMDA

### DIFF
--- a/src/iterative_ensemble_smoother/experimental.py
+++ b/src/iterative_ensemble_smoother/experimental.py
@@ -40,7 +40,6 @@ def groupby_indices(X):
     >>> list(groupby_indices(X))
     [(array([0, 0, 0]), array([1])), (array([1, 1, 1]), \
 array([3, 4])), (array([1, 2, 3]), array([0, 2, 5]))]
-
     """
     assert X.ndim == 2
 
@@ -266,6 +265,10 @@ class AdaptiveESMDA(BaseESMDA):
                     + f"{np.sum(unique_row)} / {len(unique_row)} responses."
                 )
 
+            # These parameters are not significantly correlated to any responses
+            if np.all(~unique_row):
+                continue
+
             # Get the parameters (X) that have identical significant responses (Y)
             X_subset = X[indices_of_row, :]
             Y_subset = Y[unique_row, :]
@@ -277,7 +280,12 @@ class AdaptiveESMDA(BaseESMDA):
             cov_YY_mask = np.ix_(unique_row, unique_row)
             cov_YY_subset = cov_YY[cov_YY_mask]
 
-            C_D_subset = self.C_D[unique_row]
+            # Slice the covariance matrix
+            if self.C_D.ndim == 1:
+                C_D_subset = self.C_D[unique_row]
+            else:
+                C_D_subset = self.C_D[np.ix_(unique_row, unique_row)]
+
             D_subset = D[unique_row, :]
 
             # Compute transition matrix T

--- a/src/iterative_ensemble_smoother/experimental.py
+++ b/src/iterative_ensemble_smoother/experimental.py
@@ -281,10 +281,9 @@ class AdaptiveESMDA(BaseESMDA):
             cov_YY_subset = cov_YY[cov_YY_mask]
 
             # Slice the covariance matrix
-            if self.C_D.ndim == 1:
-                C_D_subset = self.C_D[unique_row]
-            else:
-                C_D_subset = self.C_D[np.ix_(unique_row, unique_row)]
+            C_D_subset = (
+                self.C_D[unique_row] if self.C_D.ndim == 1 else self.C_D[cov_YY_mask]
+            )
 
             D_subset = D[unique_row, :]
 

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -182,8 +182,9 @@ class TestAdaptiveESMDA:
     @pytest.mark.parametrize(
         "cutoffs", [(0, 1e-3), (0.1, 0.2), (0.5, 0.5 + 1e-12), (0.9, 1), (1 - 1e-3, 1)]
     )
+    @pytest.mark.parametrize("full_covariance", [True, False])
     def test_that_posterior_generalized_variance_increases_in_cutoff(
-        self, linear_problem, cutoffs
+        self, linear_problem, cutoffs, full_covariance
     ):
         """This property only holds in the limit as the number of
         ensemble members goes to infinity. As the number of ensemble
@@ -191,6 +192,8 @@ class TestAdaptiveESMDA:
 
         # Create a problem with g(x) = A @ x
         X, g, observations, covariance, rng = linear_problem
+        if full_covariance:
+            covariance = np.diag(covariance)
 
         # =============================================================================
         # SETUP ESMDA FOR LOCALIZATION AND SOLVE PROBLEM


### PR DESCRIPTION
- Slicing for a full covariance matrix was wrong. Need to slice both dimensions.
- Added a test for this by parameterizing another test.