### PR TITLE
Optimize memory usage in empirical_cross_covariance calculation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,6 +1,7 @@
 """
 iterative_ensemble_smoother documentation build configuration file.
 """
+
 import datetime
 import os
 import re

--- a/src/iterative_ensemble_smoother/__init__.py
+++ b/src/iterative_ensemble_smoother/__init__.py
@@ -27,6 +27,7 @@ Functions
     steplength_exponential
 
 """
+
 try:
     from ._version import version as __version__
     from ._version import version_tuple

--- a/src/iterative_ensemble_smoother/esmda_inversion.py
+++ b/src/iterative_ensemble_smoother/esmda_inversion.py
@@ -77,7 +77,15 @@ def empirical_cross_covariance(
         X = X - np.mean(X, axis=1, keepdims=True)
 
     # Compute outer product and divide
-    cov = X @ Y.T / (X.shape[1] - 1)
+    # If X is a large matrix, it might be stored as a float32 array to save memory.
+    # However, if Y is of type float64,
+    # the resulting cross-covariance matrix will be float64,
+    # potentially doubling the memory usage even if X is float32.
+    # To prevent unnecessary memory consumption,
+    # we cast Y to the same data type as X before computing the dot product.
+    # This ensures that the output cross-covariance matrix uses memory efficiently
+    # while retaining the precision dictated by X's data type.
+    cov = X @ Y.astype(X.dtype).T / (X.shape[1] - 1)
     assert cov.shape == (X.shape[0], Y.shape[0])
     return cov
 

--- a/src/iterative_ensemble_smoother/experimental.py
+++ b/src/iterative_ensemble_smoother/experimental.py
@@ -2,6 +2,7 @@
 Contains (publicly available, but not officially supported) experimental
 features of iterative_ensemble_smoother
 """
+
 import numbers
 import warnings
 from typing import Callable, List, Optional, Sequence, Tuple, TypeVar, Union


### PR DESCRIPTION
Resolves: #213 

If X is a large matrix, it might be stored as a float32 array to save memory. However, if Y is of type float64,
the resulting cross-covariance matrix will be float64, potentially doubling the memory usage even if X is float32. To prevent unnecessary memory consumption,
we cast Y to the same data type as X before computing the dot product. This ensures that the output cross-covariance matrix uses memory efficiently while retaining the precision dictated by X's data type.