### PR TITLE
Set up trusted publishing to pypi

### DIFF
--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -39,6 +39,9 @@ jobs:
   upload_pypi:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment: release
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@v3
@@ -51,5 +54,4 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
-          password: ${{ secrets.pypi_password }}
           # To test: repository_url: https://test.pypi.org/legacy/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,8 @@ doc = [
     "scipy",
     "jinja2",
     "m2r2",
-    "myst_nb"
+    "myst_nb",
+    "lxml_html_clean"
 ]
 dev = [
     "pytest",


### PR DESCRIPTION
Set up according to https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/