### PR TITLE
Return all correlation pairs

### DIFF
--- a/src/iterative_ensemble_smoother/experimental.py
+++ b/src/iterative_ensemble_smoother/experimental.py
@@ -313,7 +313,7 @@ class AdaptiveESMDA(BaseESMDA):
 
         if correlation_callback is not None:
             corr_XY = self._cov_to_corr_inplace(cov_XY, stds_X, stds_Y)
-            correlation_callback(corr_XY[significant_rows])
+            correlation_callback(corr_XY)
         return X
 
 

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -62,12 +62,10 @@ class TestAdaptiveESMDA:
         )
 
         def correlation_callback(corr_matrix):
-            # A correlation threshold of 1 means that no
-            # correlations are deemed significant.
-            # Therefore, the cross-correlation matrix must
-            # not include any parameter-response pairs.
+            # cross-correlation matrix contains all correlations,
+            # even those deemed insignificant.
             print(corr_matrix)
-            assert corr_matrix.shape[0] == 0
+            assert corr_matrix.shape[0] == 50
             assert corr_matrix.shape[1] == len(observations)
 
         X_i = np.copy(X)


### PR DESCRIPTION
Users have requested to see all correlation pairs, not just the ones that are significantly correlated.

Makes it possible to implement features like this one:

https://github.com/equinor/ert/pull/9426