### PR TITLE
Add new tests to DistanceESMDA including check for convergence

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers=[
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
 ]
-dependencies = ["numpy", "scipy", "joblib"]
+dependencies = ["numpy", "scipy", "joblib", "psutil"]
 dynamic=["version"] # setuptools_scm extracts Python package versions from git
 
 authors = [


### PR DESCRIPTION
New tests to check that ESMDA and DistanceESMDA give same result when RHO matrix consists of only 1.
New test to check convergence (when increasing number of realizations) to known theoretical result (simple kriging estimate of ensemble average) for special case.
 
Updated DistanceESMDA such that internal X3 matrix is automatically created if not already created.
The use of DistanceESMDA can now be used in two different ways:
Without need for batch split-up of field parameters:
- Initialize DistanceESMDA object
- call assimilate function to update
Alternative is:
- Initialize DistanceESMDA object
- Loop over field parameter batches:
  - call assimilate_batch function to update each batch of field parameters
  - collect the update into one array

Both will do the same except that for the latter one, the update steps in the algorithm related to observations only will be done only the first time the assimilate_batch is called since in a loop over batches of field parameters, the only difference in each call to assimilate_batch is to do the steps related to field parameters and it is not necessary to do the steps with the observations more than once. When using the assimilate function instead, both the algorithm steps related to observations and field parameters are done each time (which is a bit waste of time with large observation data set like when using seismic observations).

To test memory use, a memory_usage_decorator function is added which can turn on/off a check and print of memory usage before and after calling a function.