### PR TITLE
Fix DistanceESMDA.assimilate() to use per-iteration alpha values

### DIFF
--- a/src/iterative_ensemble_smoother/experimental.py
+++ b/src/iterative_ensemble_smoother/experimental.py
@@ -565,7 +565,7 @@ class DistanceESMDA(ESMDA):
         U_r_w_inv = U_r / w_r
         # See Eqn (B.13)
         R = (
-            self.alpha
+            self.alpha[self.iteration]
             * (N_e - 1)
             * np.linalg.multi_dot([U_r_w_inv.T, C_hat_D, U_r_w_inv])
         )
@@ -592,9 +592,13 @@ class DistanceESMDA(ESMDA):
         # See Eqn (B.24)
         K_rho_i = rho * K_i
 
-        D = self.perturb_observations(ensemble_size=N_e, alpha=self.alpha)
+        D = self.perturb_observations(
+            ensemble_size=N_e, alpha=self.alpha[self.iteration]
+        )
         # See Eqn (B.25)
         X4 = K_rho_i @ (D - Y)
+
+        self.iteration += 1
 
         # See Eqn (B.26)
         return X + X4


### PR DESCRIPTION
DistanceESMDA.assimilate() was incorrectly using self.alpha (array) instead of self.alpha[self.iteration] (scalar) when computing the update and perturbing observations. This caused a broadcasting error when calling assimilate() multiple times with alpha > 1.

The fix:
- Use self.alpha[self.iteration] in the R matrix computation
- Use self.alpha[self.iteration] in perturb_observations()
- Increment self.iteration after each assimilation step

This makes DistanceESMDA consistent with the base ESMDA class behavior.

Added test_that_distance_esmda_alpha_as_integer_and_array_returns_same_result to verify the fix and prevent regression.