### PR TITLE
Use multi-dot

### DIFF
--- a/src/iterative_ensemble_smoother/experimental.py
+++ b/src/iterative_ensemble_smoother/experimental.py
@@ -577,24 +577,24 @@ class DistanceESMDA(ESMDA):
         _X = (S_inv_diag[:, np.newaxis] * U_r) * (1 / w_r) @ Z_r
 
         # See Eqn (B.19)
-        L = np.diag(1.0 / (1.0 + H_r))
+        L = np.array(1.0 / (1.0 + H_r))
 
-        # See Eqn (B.20)
-        X1 = L @ _X.T
+        # See Eqn (B.20) through (B.24)
+        # X1 = L @ _X.T
         # See Eqn (B.21)
-        X2 = D_delta.T @ _X
+        # X2 = D_delta.T @ _X
         # See Eqn (B.22)
-        X3 = X2 @ X1
+        # X3 = X2 @ X1
 
         # See Eqn (B.23)
-        K_i = M_delta @ X3
+        # K_i = M_delta @ X3
 
         # See Eqn (B.24)
-        K_rho_i = rho * K_i
+        # K_rho_i = rho * K_i
 
         D = self.perturb_observations(ensemble_size=N_e, alpha=self.alpha)
         # See Eqn (B.25)
-        X4 = K_rho_i @ (D - Y)
+        X4 = rho * np.linalg.multi_dot([M_delta, D_delta.T, _X * L, _X.T, (D - Y)])
 
         # See Eqn (B.26)
         return X + X4


### PR DESCRIPTION
The current implemenation(s) of these equations multiply them in a particular order, but an alternative order might be much faster. Unless there is a particular reason to multiply them in the current order, we should use multi_dot.

Also, a diagonal matrix was created that was not needed.

This PR is just to communicate the idea. This needs to be cleaned up a bit more and implemented several places (these equations appear duplicated. I do not know if the current implementation is a proof of concept or a serious implementation, but if/when it becomes serious it might be wise to review the linear algebra more carefully.