### PR TITLE
Remove memory_usage_decorator from experimental module

### DIFF
--- a/src/iterative_ensemble_smoother/experimental.py
+++ b/src/iterative_ensemble_smoother/experimental.py
@@ -21,14 +21,11 @@ from iterative_ensemble_smoother.esmda_inversion import (
 )
 from iterative_ensemble_smoother.utils import (
     calc_max_number_of_layers_per_batch_for_distance_localization,
-    memory_usage_decorator,
 )
 
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
-
-ENABLE_MEMORY_LOGGING_FOR_DISTANCE_BASED_LOCALIZATION = True
 
 
 class AdaptiveESMDA(BaseESMDA):
@@ -489,9 +486,6 @@ class DistanceESMDA(ESMDA):
         # Is not used when using assimilate
         self.X3: npt.NDArray[np.float64] = None
 
-    @memory_usage_decorator(
-        enabled=ENABLE_MEMORY_LOGGING_FOR_DISTANCE_BASED_LOCALIZATION
-    )
     def assimilate(
         self,
         *,
@@ -725,9 +719,6 @@ class DistanceESMDA(ESMDA):
             self.D = D
         return
 
-    @memory_usage_decorator(
-        enabled=ENABLE_MEMORY_LOGGING_FOR_DISTANCE_BASED_LOCALIZATION
-    )
     def assimilate_batch(
         self,
         *,
@@ -793,9 +784,6 @@ class DistanceESMDA(ESMDA):
         # See Eqn (B.26)
         return X_batch + X4
 
-    @memory_usage_decorator(
-        enabled=ENABLE_MEMORY_LOGGING_FOR_DISTANCE_BASED_LOCALIZATION
-    )
     def update_params_2D(
         self,
         X_prior: npt.NDArray[np.float64],
@@ -858,9 +846,6 @@ class DistanceESMDA(ESMDA):
         rho = rho_2D.reshape(nparam, nobs)
         return self.assimilate_batch(X_batch=X_prior, Y=Y, rho_batch=rho)
 
-    @memory_usage_decorator(
-        enabled=ENABLE_MEMORY_LOGGING_FOR_DISTANCE_BASED_LOCALIZATION
-    )
     def update_params_3D(
         self,
         X_prior: npt.NDArray[np.float64],

--- a/src/iterative_ensemble_smoother/utils.py
+++ b/src/iterative_ensemble_smoother/utils.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
 import logging
-import os
-import time
-from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING
 
 import numpy as np
 import psutil
@@ -110,42 +107,6 @@ def sample_mvnormal(
 
     # A 1D diagonal of a covariance matrix was passed
     return C_dd_cholesky.reshape(-1, 1) * z
-
-
-def memory_usage_decorator(
-    enabled: bool = True,
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-        @wraps(func)
-        def wrapper(*args, **kwargs) -> Any:  # type: ignore
-            if enabled:
-                # Get process ID of the current Python process
-                process = psutil.Process(os.getpid())
-
-                start_time = time.perf_counter()
-
-                # Memory usage before the function call
-                mem_before = process.memory_info().rss / 1024 / 1024  # Convert to MB
-                logger.debug(
-                    f"\nMemory before calling '{func.__name__}': {mem_before:.2f} MB"
-                )
-
-            # Call the target function
-            result = func(*args, **kwargs)
-
-            if enabled:
-                mem_after = process.memory_info().rss / 1024 / 1024  # Convert to MB
-                end_time = time.perf_counter()
-                # Memory usage after the function call
-                logger.debug(
-                    f"Memory after calling '{func.__name__}': {mem_after:.2f} MB"
-                )
-                logger.debug(f"Run time used: {(end_time - start_time):.4f} seconds")
-            return result
-
-        return wrapper
-
-    return decorator
 
 
 def calc_max_number_of_layers_per_batch_for_distance_localization(


### PR DESCRIPTION
Profiling decorators add overhead and couple debugging concerns with business logic. Users of scientific libraries should use external tools (memory_profiler, tracemalloc) for profiling as needed.