### PR TITLE
FIX: minor typo in SIES __init__ docstring

### DIFF
--- a/src/iterative_ensemble_smoother/sies.py
+++ b/src/iterative_ensemble_smoother/sies.py
@@ -64,7 +64,7 @@ class SIES:
             This is d in Evensen (2019).
         inversion : str
             The type of inversion used in the algorithm. Every inversion method
-            scales the variables. The default is `subspace.`
+            scales the variables. The default is `subspace_exact.`
             The options are:
 
                 * `direct`:


### PR DESCRIPTION
For inversion parameter in `SIES.__init__`, the default is `subspace_exact` and not `subspace`.