### PR TITLE
Verify positive distances

### DIFF
--- a/src/iterative_ensemble_smoother/utils.py
+++ b/src/iterative_ensemble_smoother/utils.py
@@ -401,6 +401,8 @@ def gaspari_cohn(
     >>> d
     array([0.5, 1.5])
     """
+    if not np.all(distances >= 0):
+        return ValueError(f"Distances must be positive. Min: {np.min(distances)}")
     scaling_factor = np.zeros_like(distances)
 
     d2 = distances**2


### PR DESCRIPTION
Better safe than sorry - a caller might expect a symmetric version about origin. This way we raise, and the caller is responsible for taking abs(). 