### PR TITLE
Widen parameter dtype from float64 to any float in assimilate_batch

### DIFF
--- a/src/iterative_ensemble_smoother/esmda.py
+++ b/src/iterative_ensemble_smoother/esmda.py
@@ -290,9 +290,9 @@ class BaseESMDA(ABC):
     def _compute_delta_M(
         self,
         *,
-        X: npt.NDArray[np.double],
+        X: npt.NDArray[np.floating],
         missing: Union[npt.NDArray[np.bool_], None] = None,
-    ) -> npt.NDArray[np.double]:
+    ) -> npt.NDArray[np.floating]:
         """Prepare delta_M := X - center(X), dealing with missing values
         as needed."""
         if not np.issubdtype(X.dtype, np.floating):

--- a/src/iterative_ensemble_smoother/esmda_localized.py
+++ b/src/iterative_ensemble_smoother/esmda_localized.py
@@ -135,13 +135,13 @@ class LocalizedESMDA(BaseESMDA):
     def assimilate_batch(
         self,
         *,
-        X: npt.NDArray[np.double],
+        X: npt.NDArray[np.floating],
         missing: Union[npt.NDArray[np.bool_], None] = None,
         localization_callback: Callable[
-            [npt.NDArray[np.double]], npt.NDArray[np.double]
+            [npt.NDArray[np.floating]], npt.NDArray[np.floating]
         ]
         | None = None,
-    ) -> npt.NDArray[np.double]:
+    ) -> npt.NDArray[np.floating]:
         """Assimilate a batch of parameters against all observations.
 
         The internal storage used by the class is 2 * ensemble_size * num_observations,
@@ -187,8 +187,8 @@ class LocalizedESMDA(BaseESMDA):
         if localization_callback is None:
 
             def localization_callback(
-                K: npt.NDArray[np.double],
-            ) -> npt.NDArray[np.double]:
+                K: npt.NDArray[np.floating],
+            ) -> npt.NDArray[np.floating]:
                 return K
 
         # Create Kalman gain of shape (num_parameters_batch, num_observations),

--- a/src/iterative_ensemble_smoother/utils.py
+++ b/src/iterative_ensemble_smoother/utils.py
@@ -103,8 +103,8 @@ def masked_std(
 
 
 def adjust_for_missing(
-    X: npt.NDArray[np.double], *, missing: npt.NDArray[np.bool_]
-) -> npt.NDArray[np.double]:
+    X: npt.NDArray[np.floating], *, missing: npt.NDArray[np.bool_]
+) -> npt.NDArray[np.floating]:
     """Removes missing values from X, such that the cross-covariance product
 
         center(X) @ center(Y).T / (N_e - 1)


### PR DESCRIPTION
The parameter matrix X can be float32 to save memory for large problems. Relax type annotations from np.double to np.floating on the parameter path: assimilate_batch, _compute_delta_M, and adjust_for_missing.

Internal matrices (observations, covariance, SVD intermediates) remain float64 for numerical precision.