### PR TITLE
Widen np.double to np.floating for parameter annotations

### DIFF
--- a/src/iterative_ensemble_smoother/esmda.py
+++ b/src/iterative_ensemble_smoother/esmda.py
@@ -355,9 +355,9 @@ class ESMDA(BaseESMDA):
     def assimilate_batch(
         self,
         *,
-        X: npt.NDArray[np.double],
+        X: npt.NDArray[np.floating],
         missing: Union[npt.NDArray[np.bool_], None] = None,
-    ) -> npt.NDArray[np.double]:
+    ) -> npt.NDArray[np.floating]:
         """Assimilate a batch of parameters against all observations.
 
         The internal storage used by the class is 2 * ensemble_size * num_observations,

--- a/src/iterative_ensemble_smoother/esmda_adaptive.py
+++ b/src/iterative_ensemble_smoother/esmda_adaptive.py
@@ -98,9 +98,9 @@ class AdaptiveESMDA(BaseESMDA):
 
     @staticmethod
     def three_over_sqrt_n(
-        corr_XY: npt.NDArray[np.double],
+        corr_XY: npt.NDArray[np.floating],
         observations_per_parameter: npt.NDArray[np.int_],
-    ) -> npt.NDArray[np.double]:
+    ) -> npt.NDArray[np.floating]:
         """Use the correlation threshold 3 / sqrt(n). Note that unless
         the number of ensemble members is > 9, all responses are removed
         and no update happens at all.
@@ -120,13 +120,13 @@ class AdaptiveESMDA(BaseESMDA):
     def assimilate_batch(
         self,
         *,
-        X: npt.NDArray[np.double],
+        X: npt.NDArray[np.floating],
         missing: Union[npt.NDArray[np.bool_], None] = None,
         correlation_callback: Callable[
-            [npt.NDArray[np.double], npt.NDArray[np.int_]], npt.NDArray[np.double]
+            [npt.NDArray[np.floating], npt.NDArray[np.int_]], npt.NDArray[np.floating]
         ]
         | None = None,
-    ) -> npt.NDArray[np.double]:
+    ) -> npt.NDArray[np.floating]:
         """Assimilate a batch of parameters against all observations.
 
         The internal storage used by the class is 2 * ensemble_size * num_observations,
@@ -170,9 +170,9 @@ class AdaptiveESMDA(BaseESMDA):
         if correlation_callback is None:
 
             def correlation_callback(
-                corr_XY: npt.NDArray[np.double],
+                corr_XY: npt.NDArray[np.floating],
                 observations_per_parameter: npt.NDArray[np.int_],
-            ) -> npt.NDArray[np.double]:
+            ) -> npt.NDArray[np.floating]:
                 return np.ones_like(corr_XY, dtype=np.bool_)
 
         # Step 1: COMPUTE THE CROSS-COVARIANCE/CORRELATION AND APPLY CALLBACK
@@ -258,8 +258,8 @@ class AdaptiveESMDA(BaseESMDA):
 
     @staticmethod
     def _clip_correlation_matrix(
-        corr_XY: npt.NDArray[np.double],
-    ) -> npt.NDArray[np.double]:
+        corr_XY: npt.NDArray[np.floating],
+    ) -> npt.NDArray[np.floating]:
         """Clip correlation array to range [-1, 1]."""
 
         # Perform checks and clip values to [-1, 1]

--- a/src/iterative_ensemble_smoother/esmda_inversion.py
+++ b/src/iterative_ensemble_smoother/esmda_inversion.py
@@ -254,8 +254,8 @@ import scipy as sp  # type: ignore
 
 
 def empirical_cross_covariance(
-    X: npt.NDArray[np.double], Y: npt.NDArray[np.double]
-) -> npt.NDArray[np.double]:
+    X: npt.NDArray[np.floating], Y: npt.NDArray[np.floating]
+) -> npt.NDArray[np.floating]:
     """Both X and Y have shape (parameters, ensemble_size).
 
     We use this function instead of np.cov to handle cross-correlation,

--- a/src/iterative_ensemble_smoother/experimental.py
+++ b/src/iterative_ensemble_smoother/experimental.py
@@ -29,10 +29,10 @@ class RowScaledESMDA(ESMDA):
     def assimilate_batch(
         self,
         *,
-        X: npt.NDArray[np.double],
+        X: npt.NDArray[np.floating],
         missing: Union[npt.NDArray[np.bool_], None] = None,
         alpha: float = 1.0,
-    ) -> npt.NDArray[np.double]:
+    ) -> npt.NDArray[np.floating]:
         """Apply a scaling `alpha` to the update."""
         if not hasattr(self, "delta_DT"):
             raise Exception("The method `prepare_assmilation` must be called.")
@@ -66,7 +66,7 @@ def ensemble_smoother_update_step_row_scaling(
     *,
     covariance: npt.NDArray[np.double],
     observations: npt.NDArray[np.double],
-    X_with_row_scaling: List[Tuple[npt.NDArray[np.double], RowScaling]],
+    X_with_row_scaling: List[Tuple[npt.NDArray[np.floating], RowScaling]],
     Y: npt.NDArray[np.double],
     seed: Union[np.random._generator.Generator, int, None] = None,
     truncation: float = 1.0,

--- a/src/iterative_ensemble_smoother/utils.py
+++ b/src/iterative_ensemble_smoother/utils.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 def groupby_rows(
-    A: npt.NDArray[np.double],
+    A: npt.NDArray[np.bool_],
 ) -> Iterator[tuple[npt.NDArray[np.int_], npt.NDArray[np.bool_]]]:
     """Yields pairs (row_indices, columns).
 
@@ -50,8 +50,8 @@ def groupby_rows(
 
 
 def masked_std(
-    X: npt.NDArray[np.double], *, missing: npt.NDArray[np.bool_]
-) -> npt.NDArray[np.double]:
+    X: npt.NDArray[np.floating], *, missing: npt.NDArray[np.bool_]
+) -> npt.NDArray[np.floating]:
     """Computes a masked std for each row in X.
 
     Examples
@@ -193,7 +193,7 @@ def adjust_for_missing(
 
 
 def _validate_inputs(
-    parameters: npt.NDArray[np.double],
+    parameters: npt.NDArray[np.floating],
     covariance: npt.NDArray[np.double],
     observations: npt.NDArray[np.double],
 ) -> None:


### PR DESCRIPTION
Apply the same dtype relaxation from the previous commit to all remaining parameter-facing signatures across esmda, esmda_adaptive, esmda_inversion, experimental, and utils. Also fix groupby_rows input annotation from np.double to np.bool_.