### PR TITLE
Add copy parameter to assimilate_batch for in-place updates

### DIFF
--- a/src/iterative_ensemble_smoother/esmda.py
+++ b/src/iterative_ensemble_smoother/esmda.py
@@ -357,6 +357,7 @@ class ESMDA(BaseESMDA):
         *,
         X: npt.NDArray[np.floating],
         missing: Union[npt.NDArray[np.bool_], None] = None,
+        copy: bool = True,
     ) -> npt.NDArray[np.floating]:
         """Assimilate a batch of parameters against all observations.
 
@@ -376,6 +377,9 @@ class ESMDA(BaseESMDA):
             happen if the ensemble members use different grids, where each
             ensemble member has a slightly different grid layout. If None,
             then all entries are assumed to be valid.
+        copy : bool, optional
+            If True (default), a copy of X is made before modification.
+            Set to False to update X in-place and avoid the extra allocation.
 
         Returns
         -------
@@ -383,6 +387,8 @@ class ESMDA(BaseESMDA):
             2D array of shape (num_parameters_batch, ensemble_size).
 
         """
+        if copy:
+            X = X.copy()
         if not hasattr(self, "delta_DT"):
             raise Exception("The method `prepare_assmilation` must be called.")
         N_m, N_e = X.shape  # (num_parameters, ensemble_size)
@@ -390,9 +396,10 @@ class ESMDA(BaseESMDA):
 
         # In standard ESMDA, we simplify compute the product in a good order
         delta_M = self._compute_delta_M(X=X, missing=missing)
-        return X + np.linalg.multi_dot(
+        X += np.linalg.multi_dot(
             [delta_M, self.delta_DT, self.term_diag, self.termT, self.D_obs_minus_D]
         )
+        return X
 
 
 if __name__ == "__main__":

--- a/src/iterative_ensemble_smoother/esmda_adaptive.py
+++ b/src/iterative_ensemble_smoother/esmda_adaptive.py
@@ -126,6 +126,7 @@ class AdaptiveESMDA(BaseESMDA):
             [npt.NDArray[np.floating], npt.NDArray[np.int_]], npt.NDArray[np.floating]
         ]
         | None = None,
+        copy: bool = True,
     ) -> npt.NDArray[np.floating]:
         """Assimilate a batch of parameters against all observations.
 
@@ -150,6 +151,9 @@ class AdaptiveESMDA(BaseESMDA):
             (num_parameters_batch, num_observations) and returns a 2D array of
             the same shape. The returned array represents any kind of correlation
             thresholding or softening.
+        copy : bool, optional
+            If True (default), a copy of X is made before modification.
+            Set to False to update X in-place and avoid the extra allocation.
 
         Returns
         -------
@@ -157,6 +161,8 @@ class AdaptiveESMDA(BaseESMDA):
             2D array of shape (num_parameters_batch, ensemble_size).
 
         """
+        if copy:
+            X = X.copy()
         if not hasattr(self, "D_obs_minus_D"):
             raise Exception("The method `prepare_assmilation` must be called.")
 
@@ -210,7 +216,6 @@ class AdaptiveESMDA(BaseESMDA):
 
         # Step 2: APPLY UPDATES TO EACH PARAMETER, USING CORRELATED RESPONSES
         # ===================================================================
-        result = np.zeros_like(X, dtype=X.dtype)
 
         alpha = self.alpha[self.iteration]
         delta_D = self.delta_DT.T
@@ -245,7 +250,7 @@ class AdaptiveESMDA(BaseESMDA):
 
             # Multiply together and store results
             corr_mask = np.ix_(param_idx, response_idx)
-            result[param_idx, :] = np.linalg.multi_dot(
+            X[param_idx, :] += np.linalg.multi_dot(
                 [
                     corr_XY[corr_mask],
                     factor1,
@@ -254,7 +259,7 @@ class AdaptiveESMDA(BaseESMDA):
                 ]
             )
 
-        return X + result
+        return X
 
     @staticmethod
     def _clip_correlation_matrix(

--- a/src/iterative_ensemble_smoother/esmda_localized.py
+++ b/src/iterative_ensemble_smoother/esmda_localized.py
@@ -141,6 +141,7 @@ class LocalizedESMDA(BaseESMDA):
             [npt.NDArray[np.floating]], npt.NDArray[np.floating]
         ]
         | None = None,
+        copy: bool = True,
     ) -> npt.NDArray[np.floating]:
         """Assimilate a batch of parameters against all observations.
 
@@ -167,6 +168,9 @@ class LocalizedESMDA(BaseESMDA):
             parameter and observation a localiation factor between 0 and 1,
             and apply element multiplication. The default is None, which applies
             the identity function (i.e. multiplication with 1 in every entry).
+        copy : bool, optional
+            If True (default), a copy of X is made before modification.
+            Set to False to update X in-place and avoid the extra allocation.
 
         Returns
         -------
@@ -174,6 +178,8 @@ class LocalizedESMDA(BaseESMDA):
             2D array of shape (num_parameters_batch, ensemble_size).
 
         """
+        if copy:
+            X = X.copy()
         if not hasattr(self, "delta_DT"):
             raise Exception("The method `prepare_assmilation` must be called.")
         N_m, N_e = X.shape  # (num_parameters, ensemble_size)
@@ -196,7 +202,8 @@ class LocalizedESMDA(BaseESMDA):
         K = localization_callback(
             np.linalg.multi_dot([delta_M, self.delta_DT, self.term_diag, self.termT])
         )
-        return X + K @ self.D_obs_minus_D
+        X += K @ self.D_obs_minus_D
+        return X
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Allow callers to skip the defensive copy of X by passing copy=False, reducing memory allocations. All three ESMDA variants (ESMDA, AdaptiveESMDA, LocalizedESMDA) now use in-place += for the update step.