### PR TITLE
Use myst for markdown and upgrade urllib

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,7 +41,6 @@ extensions = [
     "sphinxcontrib.bibtex",
     "jupyter_sphinx",
     "numpydoc",
-    "m2r2",  # compatibility with markdown
     "myst_nb",  # to include jupyter notebooks
 ]
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,6 +1,7 @@
 **Date**: |today| **Version**: |version|
 
-.. mdinclude:: ../../README.md
+.. include:: ../../README.md
+   :parser: myst_parser.sphinx_
 
 .. toctree::
    :hidden:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ doc = [
     "numpydoc",
     "scipy",
     "jinja2",
-    "m2r2>=0.3.3",
     "myst_nb",
     "lxml_html_clean"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,3 +171,6 @@ max-complexity = 10
 [tool.uv]
 fork-strategy = "requires-python"
 exclude-newer = "7 days"
+
+[tool.uv.exclude-newer-package]
+urllib3 = false # Needed until 14.05 for security update

--- a/uv.lock
+++ b/uv.lock
@@ -816,7 +816,6 @@ doc = [
     { name = "jupyter-sphinx" },
     { name = "jupytext" },
     { name = "lxml-html-clean" },
-    { name = "m2r2" },
     { name = "matplotlib" },
     { name = "myst-nb" },
     { name = "numpydoc" },
@@ -842,7 +841,6 @@ requires-dist = [
     { name = "jupyter-sphinx", marker = "extra == 'doc'" },
     { name = "jupytext", marker = "extra == 'doc'" },
     { name = "lxml-html-clean", marker = "extra == 'doc'" },
-    { name = "m2r2", marker = "extra == 'doc'", specifier = ">=0.3.3" },
     { name = "matplotlib", marker = "extra == 'dev'" },
     { name = "matplotlib", marker = "extra == 'doc'" },
     { name = "mypy", marker = "extra == 'dev'" },
@@ -1342,19 +1340,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9a/a4/5c62acfacd69ff4f5db395100f5cfb9b54e7ac8c69a235e4e939fd13f021/lxml_html_clean-0.4.4.tar.gz", hash = "sha256:58f39a9d632711202ed1d6d0b9b47a904e306c85de5761543b90e3e3f736acfb", size = 23899, upload-time = "2026-02-27T09:35:52.911Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/76/7ffc1d3005cf7749123bc47cb3ea343cd97b0ac2211bab40f57283577d0e/lxml_html_clean-0.4.4-py3-none-any.whl", hash = "sha256:ce2ef506614ecb85ee1c5fe0a2aa45b06a19514ec7949e9c8f34f06925cfabcb", size = 14565, upload-time = "2026-02-27T09:35:51.86Z" },
-]
-
-[[package]]
-name = "m2r2"
-version = "0.3.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "docutils" },
-    { name = "mistune" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/26/a9/ab03ff21972cfb2e6ea766b1dc015c2c081af70f8f956806e948c62044ba/m2r2-0.3.4.tar.gz", hash = "sha256:e278f5f337e9aa7b2080fcc3e94b051bda9615b02e36c6fb3f23ff019872f043", size = 17082, upload-time = "2025-05-01T16:55:53.244Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/50/5b1d70de548fb1e11e15ea9ebec0480365462d202f98b66ad7e154284327/m2r2-0.3.4-py3-none-any.whl", hash = "sha256:1a445514af8a229496bfb1380c52da8dd38313e48600359ee92b2c9d2e4df34a", size = 11199, upload-time = "2025-05-01T16:55:51.87Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,9 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
+[options.exclude-newer-package]
+urllib3 = false
+
 [[package]]
 name = "accessible-pygments"
 version = "0.0.5"
@@ -3106,11 +3109,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
myst_nb comes with baked in myst_parser for markdown support so no need to use m2e2 which has some dependencies with vulnerabilities.

Also explicitly upgrade urllib3 due to CVE-2026-44432

<img width="1423" height="1399" alt="image" src="https://github.com/user-attachments/assets/220f5ba7-6342-46f7-83cb-f2a507a3f8cc" />
